### PR TITLE
Forced refresh to fix widget disappearing in edit mode

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -515,7 +515,7 @@ var app = new Vue({
       // Save and close
       $vm.save().then(function() {
         Fliplet.Widget.complete();
-        Fliplet.Studio.emit('reload-widget-instance', widgetId);
+        Fliplet.Studio.emit('reload-page-preview');
       });
     }
 


### PR DESCRIPTION
In some instances where the form is too big and the page has scroll, the `Fliplet.Studio.emit('reload-widget-instance', widgetId);` isn't enough.
So the refresh of the page preview is called after saving with `Fliplet.Studio.emit('reload-page-preview');`.

Still related to this: https://github.com/Fliplet/fliplet-studio/issues/978