### PR TITLE
make sure given value for checkbox is an array

### DIFF
--- a/js/components/checkbox.js
+++ b/js/components/checkbox.js
@@ -16,5 +16,11 @@ Fliplet.FormBuilder.field('checkbox', {
         }
       ]
     }
+  },
+  created: function () {
+    if (!Array.isArray(this.value)) {
+      this.value = [];
+      this.updateValue(this.name, this.value)
+    }
   }
 });

--- a/js/components/checkbox.js
+++ b/js/components/checkbox.js
@@ -20,7 +20,7 @@ Fliplet.FormBuilder.field('checkbox', {
   created: function () {
     if (!Array.isArray(this.value)) {
       this.value = [];
-      this.updateValue(this.name, this.value)
+      this.updateValue(this.name, this.value);
     }
   }
 });

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -100,7 +100,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
           }
         });
 
-        if (data.saveProgress) {
+        if (typeof data.saveProgress === 'function') {
           this.saveProgress();
         }
       },


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/1460

---

This is mainly for existing forms or widget instances that incorrectly give a non-array value as default or existing value for any checkbox field.