### PR TITLE
escape for handlebars variables

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -263,7 +263,7 @@ var app = new Vue({
 
       fields.forEach(function(field) {
         if (typeof field._submit === 'undefined' || field._submit) {
-          defaultEmailTemplate += '<li style="line-height: 24px;">' + field.label + ': {{' + field.name + '}}</li>';
+          defaultEmailTemplate += '<li style="line-height: 24px;">' + field.label + ': {{[' + field.name + ']}}</li>';
         }
       });
       defaultEmailTemplate += '</ul>';


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/1532

---

### From the docs:

**Identifiers may be any unicode character except for the following:**

> Whitespace ! " # % & ' ( ) * + , . / ; < = > @ [ \ ] ^ ` { | } ~

To reference a property that is not a valid identifier, you can use segment-literal notation, `[`.

http://handlebarsjs.com/expressions.html