### PR TITLE
one more fix for ie11

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -261,7 +261,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
         //   }));
         // });
       },
-      loadEntryForUpdate() {
+      loadEntryForUpdate: function() {
         var $vm = this;
 
         if (entryId) {


### PR DESCRIPTION
I didn't find any other occurrence looking for `[a-z]+\(\) ?{`.