### PR TITLE
Adds data-field to .form-group container to help identify containers

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -21,7 +21,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.email"] = Handlebar
 this["Fliplet"]["Widget"]["Templates"]["templates.components.field"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
     var stack1, helper;
 
-  return "<div class=\"form-group row clearfix\">\n  <div class=\"col-xs-12\">\n    <label v-if=\"_isFormField\" :for=\"name\">\n    	{{ label }} <template v-if=\"required\"><span class=\"required-info\">*</span></template>\n    </label>\n  </div>\n  <div class=\"col-xs-12\">\n    "
+  return "<div class=\"form-group row clearfix\" :data-field=\"name\">\n  <div class=\"col-xs-12\">\n    <label v-if=\"_isFormField\" :for=\"name\">\n      {{ label }} <template v-if=\"required\"><span class=\"required-info\">*</span></template>\n    </label>\n  </div>\n  <div class=\"col-xs-12\">\n    "
     + ((stack1 = ((helper = (helper = helpers.template || (depth0 != null ? depth0.template : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"template","hash":{},"data":data}) : helper))) != null ? stack1 : "")
     + "\n  </div>\n</div>\n";
 },"useData":true});

--- a/templates/components/field.build.hbs
+++ b/templates/components/field.build.hbs
@@ -1,7 +1,7 @@
-<div class="form-group row clearfix">
+<div class="form-group row clearfix" :data-field="name">
   <div class="col-xs-12">
     <label v-if="_isFormField" :for="name">
-    	\{{ label }} <template v-if="required"><span class="required-info">*</span></template>
+      \{{ label }} <template v-if="required"><span class="required-info">*</span></template>
     </label>
   </div>
   <div class="col-xs-12">


### PR DESCRIPTION
This makes it easier to hide a field through custom:

```js
$('[data-field="Question 1"]').hide();
```

Result:

<img width="411" alt="screen shot 2017-11-16 at 14 06 09" src="https://user-images.githubusercontent.com/290733/32895255-59b12bf2-cad7-11e7-95fb-2ae66f9e61cc.png">
