### PR TITLE
new events and listeners

### DIFF
--- a/build.html
+++ b/build.html
@@ -20,7 +20,7 @@
       <div v-if="isOffline" class="text-danger" v-bind:class="{ 'cover-form' : blockScreen }" v-html="isOfflineMessage"></div>
       <div v-if="hasRequiredFields" class="required-info-label">* Required fields</div>
       <template v-for="field in fields">
-        <component :is="field._type" v-bind="field" v-on:_input="onInput" v-on:_error="onError" v-on:_reset="reset"></component>
+        <component :is="field._type" v-bind="field" v-on:_input="onInput" v-on:_error="onError" v-on:_reset="reset" v-if="field.enabled"></component>
       </template>
       <div class="callout callout-danger" v-if="error">
         <p>\{{ error }}</p>

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -126,7 +126,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
         this.fields.forEach(function(field, index) {
           field.value = data.fields[index].value;
-          this.triggerChange(field.name, field.value);
+          $vm.triggerChange(field.name, field.value);
         });
 
         Fliplet.FormBuilder.emit('reset');

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -249,7 +249,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
           var value = field.value;
           var type = field._type;
 
-          if (field._submit === false) {
+          if (field._submit === false || !field.enabled) {
             return;
           }
 
@@ -400,7 +400,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
         var progress = {};
 
         $vm.fields.forEach(function(field) {
-          if (field.saveProgress !== false) {
+          if (field.saveProgress !== false && field.enabled) {
             progress[field.name] = field.value;
           }
         });
@@ -409,10 +409,6 @@ Fliplet.Widget.instance('form-builder', function(data) {
       }, saveDelay);
 
       $(selector).removeClass('is-loading');
-
-      Fliplet.Hooks.on('beforeFormSubmit', function(data) {
-        console.log('[Hook] beforeFormSubmit', data);
-      });
 
       if (!data.offline) {
         Fliplet.Navigator.onOnline(function() {


### PR DESCRIPTION
Two new methods added to form fields:

- `change(fn [,runOnBind = true])` registers a function to be called whenever the field value changes
- `toggle(bool)` shows and hides the field, also reverting its value to the default value. Field will also not be posted and progress won't be saved

```js
Fliplet.FormBuilder.get().then(function (form) {

  // registers a callback to be fired whenever the field value changes
  form.field('Question 1').change(function (val) {

    // only show / enable this field when val is "foo"
    // works like jQuery "toggle", which evaluates the argument as a "truthy" boolean.
    form.field('Question 2').toggle(val === 'foo');

  });

});
```