### PR TITLE
Changed to different navstack reference

### DIFF
--- a/js/libs/core.js
+++ b/js/libs/core.js
@@ -230,7 +230,7 @@ Fliplet.FormBuilder = (function() {
           Fliplet.Studio.emit('widget-save-label-update');
           $vm.mediaFolderData = result.data[0];
           $vm.mediaFolderId = result.data[0].id;
-          $vm.mediaFolderNavStack = result.data[1]
+          $vm.mediaFolderNavStack = result.data[0].navStackRef || {};
           window.currentProvider = null;
         });
       }


### PR DESCRIPTION
Because we changed the navstack reference created by the file picker in https://github.com/Fliplet/fliplet-widget-file-picker/pull/25 we needed to update the code to be able to open the file manager in the correct folder