### PR TITLE
fix for non-numeric field value

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -273,8 +273,8 @@ Fliplet.Widget.instance('form-builder', function(data) {
               appendField(field.name, value.item(i));
             }
           } else {
-            // Remove spaces and dashes from value
-            if (type === 'flNumber' || type === '"flTelephone"') {
+            // Remove spaces and dashes from value (when it's a string)
+            if (typeof value === 'string' &&  ['flNumber', 'flTelephone'].indexOf(type) !== -1)
               value = value.replace(/-|\s/g, '');
             }
             if (type === 'flDate') {


### PR DESCRIPTION
if the value is not a string we cannot use `replace`.