### PR TITLE
Ensures padding adjustment is not unnecessarily applied to .container-fluid

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -636,9 +636,6 @@ form hr {
 /* @MEDIA */
 
 @media screen and (min-width: 640px) {
-  .container-fluid {
-    padding: 0 12.5%;
-  }
   .btn-link,
   .btn-primary,
   .btn-secondary {


### PR DESCRIPTION
The Bootstrap class `.container-fluid` is being manipulated by the form builder widget. This should not be the case and it does not appear the form builder is relying on it.

This results in left & right paddings being added to a page simply because a form builder is dropped onto a page.

This 12.5% left/right padding is removed in this PR.