### PR TITLE
missing reference

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -16,7 +16,8 @@
       "fliplet-datasources",
       "codemirror",
       "bootstrap",
-      "moment"
+      "moment",
+      "tinymce"
     ],
     "assets": [
       "vendor/sortable.js",


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-e2e-tests/issues/141

turns out tinymce is being used by the interface here https://github.com/Fliplet/fliplet-widget-form-builder/blob/master/js/libs/builder.js#L834-L835