### PR TITLE
Replace TinyMCE iframe with a ghost container in the widget interface

### DIFF
--- a/css/builder.css
+++ b/css/builder.css
@@ -812,3 +812,7 @@ form hr {
 .selected-folder-holder {
   margin-top: 5px;
 }
+
+.ghost-tinymce {
+  padding: 10px 8px 8px !important;
+}

--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -91,7 +91,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.url"] = Handlebars.
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.wysiwyg"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<textarea\n  class=\"form-control\"\n  v-model.trim=\"value\"\n  v-on:input=\"updateValue()\"\n  ref=\"textarea\"\n  :name=\"name\"\n  :id=\"name\"\n  :required=\"required\"\n></textarea>";
+    return "<textarea\n  class=\"form-control\"\n  v-model.trim=\"value\"\n  v-on:input=\"updateValue()\"\n  ref=\"textarea\"\n  :name=\"name\"\n  :id=\"name\"\n  :required=\"required\"\n></textarea>\n<div\n  class=\"ghost-tinymce\"\n  ref=\"ghost\"\n  v-html=\"value\"\n  v-if=\"isInterface\">\n</div>";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.configurations.radio"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -10,6 +10,11 @@ Fliplet.FormBuilder.field('wysiwyg', {
       default: 8
     }
   },
+  computed: {
+    isInterface: function () {
+      return Fliplet.Env.get('interface');
+    }
+  },
   watch: {
     value: function (val) {
       // This happens when the value is updated programmatically via the FormBuilder field().val() method
@@ -74,6 +79,14 @@ Fliplet.FormBuilder.field('wysiwyg', {
 
           // Default font size
           editor.execCommand('fontSize', false, '10pt');
+
+          if ($vm.isInterface) {
+            // iFrames don't work with the form builder's Sortable feature
+            // Instead, the iFrame is swapped with a <div></div> of the same dimensions
+            var $el = $($vm.$refs.ghost);
+            $el.width(editor.iframeElement.style.width).height(editor.iframeElement.style.height);
+            $(editor.iframeElement).replaceWith($el);
+          }
         });
 
         editor.on('change', function(e) {

--- a/templates/components/wysiwyg.build.hbs
+++ b/templates/components/wysiwyg.build.hbs
@@ -7,3 +7,9 @@
   :id="name"
   :required="required"
 ></textarea>
+<div
+  class="ghost-tinymce"
+  ref="ghost"
+  v-html="value"
+  v-if="isInterface">
+</div>


### PR DESCRIPTION
This fixes an issue where WYSIWYG form field is not draggable in the interface because Sortable doesn't work when the draggable items includes an iFrame.