### PR TITLE
Fixes issue when fields can't be added on IE

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -174,7 +174,7 @@ var app = new Vue({
         component = Fliplet.FormBuilder.components()[componentName];
         value = component.props.value;
 
-        event.item.remove();
+        $(event.item).remove();
 
         var i = (_.max(_.compact(_.map(this.fields, function (field) {
           var idx = field.name.match(/^field-([0-9]+)/);


### PR DESCRIPTION
Ref. https://sentry.io/fliplet/production-widgets-interface/issues/647695190/?query=is:unresolved%20com.fliplet.form-builder

Haven't been able to verify the issue is definitely occurring but based on the Sentry error and that `node.remove()` isn't supported on IE, I'm guessing this should do the trick of resolving the Sentry error.