### PR TITLE
Various fixes with WYSIWYG editor field

### DIFF
--- a/css/builder.css
+++ b/css/builder.css
@@ -816,3 +816,7 @@ form hr {
 .ghost-tinymce {
   padding: 10px 8px 8px !important;
 }
+
+.mce-container-body .mce-edit-area {
+  overflow: hidden;
+}

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -1,6 +1,6 @@
 Fliplet.FormBuilder.field('wysiwyg', {
-  name: 'WYSIWYG Editor',
-  category: 'Advanced',
+  name: 'Rich text',
+  category: 'Text inputs',
   props: {
     placeholder: {
       type: String

--- a/widget.json
+++ b/widget.json
@@ -37,6 +37,7 @@
       "js/components/url.js",
       "js/components/password.js",
       "js/components/textarea.js",
+      "js/components/wysiwyg.js",
       "js/components/select.js",
       "js/components/radio.js",
       "js/components/checkbox.js",
@@ -50,7 +51,6 @@
       "js/components/date.js",
       "js/components/time.js",
       "js/components/signature.js",
-      "js/components/wysiwyg.js",
 
       "js/configurations/input.js",
       "js/configurations/email.js",


### PR DESCRIPTION
- Renames **WYSIWYG editor** field to **Rich text**
- Moves **WYSIWYG editor** field to under **Multiple line input** field in the **Text inputs** category
- Fixes an issue with **WYSIWYG editor** field that created horizontal scrolling

![image](https://user-images.githubusercontent.com/290733/45772709-485d6380-bbfd-11e8-81d3-5ba28b5847dd.png)
