### PR TITLE
Fixes issue with date picker UI being too wide

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -693,6 +693,12 @@ form hr {
   float: none;
 }
 
+/* Date picker */
+
+.datepicker table tr td,
+.datepicker table tr th {
+  min-width: 44px;
+}
 
 /* TinyMCE source code area */
 


### PR DESCRIPTION
### Before

<img width="394" alt="screen shot 2018-09-19 at 12 09 29" src="https://user-images.githubusercontent.com/290733/45775564-f8829a80-bc04-11e8-813f-8d805ffedad5.png">

### After

<img width="399" alt="screen shot 2018-09-19 at 12 09 43" src="https://user-images.githubusercontent.com/290733/45775568-fb7d8b00-bc04-11e8-829f-6024183a77bf.png">
