### PR TITLE
Fixes various issues with WYSIWYG field

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -80,6 +80,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
       autoresize_bottom_margin: 50,
       autoresize_max_height: 500,
       autoresize_min_height: 20 * this.rows,
+      autofocus: false,
       branding: false,
       setup: function (editor) {
         editor.on('init', function () {

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -7,7 +7,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
     },
     rows: {
       type: Number,
-      default: 8
+      default: 5
     }
   },
   computed: {
@@ -48,6 +48,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
   },
   mounted: function () {
     var $vm = this;
+    var lineHeight = 40;
 
     tinymce.init({
       target: this.$refs.textarea,
@@ -70,10 +71,10 @@ Fliplet.FormBuilder.field('wysiwyg', {
       menubar: false,
       statusbar: false,
       inline: false,
-      resize: true,
-      autoresize_bottom_margin: 50,
-      autoresize_max_height: 500,
-      autoresize_min_height: 20 * this.rows,
+      resize: false,
+      autoresize_bottom_margin: 0,
+      autoresize_max_height: lineHeight * this.rows,
+      autoresize_min_height: lineHeight * this.rows,
       autofocus: false,
       branding: false,
       setup: function (editor) {

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -84,10 +84,6 @@ Fliplet.FormBuilder.field('wysiwyg', {
       setup: function (editor) {
         editor.on('init', function () {
           $vm.editor = editor;
-
-          // Default font size
-          editor.execCommand('fontSize', false, '10pt');
-
           if ($vm.isInterface) {
             // iFrames don't work with the form builder's Sortable feature
             // Instead, the iFrame is swapped with a <div></div> of the same dimensions

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -37,12 +37,6 @@ Fliplet.FormBuilder.field('wysiwyg', {
 
       this.value = '';
     },
-    onSubmit: function () {
-      if (this.editor) {
-        this.editor.destroy();
-        this.editor = null;
-      }
-    },
     onBeforeSubmit: function(data) {
       var value = data[this.name];
       $(this.$refs.textarea).parents('.form-group').removeClass('has-error');
@@ -101,10 +95,14 @@ Fliplet.FormBuilder.field('wysiwyg', {
     });
 
     Fliplet.Hooks.on('beforeFormSubmit', this.onBeforeSubmit);
-    Fliplet.Hooks.on('afterFormSubmit', this.onSubmit);
     Fliplet.FormBuilder.on('reset', this.onReset);
   },
   destroyed: function() {
+    if (this.editor) {
+      this.editor.destroy();
+      this.editor = null;
+    }
+
     Fliplet.FormBuilder.off('reset', this.onReset);
   }
 });


### PR DESCRIPTION
Ref. Items 1, 7-9 in https://github.com/Fliplet/fliplet-studio/issues/3257

- text area keeps expanding, has padding at the bottom:
![image](https://user-images.githubusercontent.com/6480848/45897502-329f9800-bdcf-11e8-8f55-2bafbf989f94.png)

- When you add it to a screen it automatically focusses the cursor on itself, this shouldn't happen. 

- By default it is setting a font size, it shouldn't, otherwise it looks different to the rest of the content on the screen e.g. LFD displays its output.
![image](https://user-images.githubusercontent.com/6480848/46039983-0a81a300-c107-11e8-86ce-16a9fc40c16c.png)

- on submission the preview shows the HTML code:
![image](https://user-images.githubusercontent.com/6480848/45898367-b6f31a80-bdd1-11e8-9e39-7d64978fd9d5.png)
