### PR TITLE
fixes for composing emails twice

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -330,16 +330,16 @@ Fliplet.Widget.instance('form-builder', function(data) {
           // Emails are only sent by the client when data source hooks aren't set
           if (!data.dataSourceId) {
             if (data.emailTemplateAdd && data.onSubmit && data.onSubmit.indexOf('templatedEmailAdd') > -1) {
-              operation = Fliplet.Communicate.sendEmail(data.emailTemplateAdd, formData);
+              operation = Fliplet.Communicate.sendEmail(_.extend({}, data.emailTemplateAdd), formData);
             }
 
             if (data.emailTemplateEdit && data.onSubmit && data.onSubmit.indexOf('templatedEmailEdit') > -1) {
-              operation = Fliplet.Communicate.sendEmail(data.emailTemplateEdit, formData);
+              operation = Fliplet.Communicate.sendEmail(_.extend({}, data.emailTemplateEdit), formData);
             }
           }
 
           if (data.generateEmailTemplate && data.onSubmit && data.onSubmit.indexOf('generateEmail') > -1) {
-            operation = Fliplet.Communicate.composeEmail(data.generateEmailTemplate, formData);
+            operation = Fliplet.Communicate.composeEmail(_.extend({}, data.generateEmailTemplate), formData);
           }
 
           if (data.linkAction && data.redirect) {


### PR DESCRIPTION
Issue: the template(s) from the formbuilder were getting compiled and altered hence using them a second time would have lost the handlebars templated code.

ref https://github.com/Fliplet/fliplet-studio/issues/3334 https://github.com/Fliplet/fliplet-studio/issues/3088