### PR TITLE
Fixed a date-prefilling issue occuring on native platforms

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -60,7 +60,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
             if (Fliplet.Env.get('platform') === 'web') {
               field.value = moment(entry.data[field.name]).format('DD MMMM YYYY');
             } else {
-              field.value = moment(entry.data[field.name]).format('DD/MM/YYYY');
+              field.value = moment(entry.data[field.name]).format('YYYY-MM-DD');
             }
           } else if (field._type === "flCheckbox" && !Array.isArray(entry.data[field.name])) {
             field.value = [];


### PR DESCRIPTION
[According to MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#Value) the default date format for all `<input type="date">` is YYYY-MM-DD while we were re-formatting the value in `DD/MM/YYYY` which caused ios native to not render the value.