### PR TITLE
Fixes a huge space at the top of the form selecting state

### DIFF
--- a/css/builder.css
+++ b/css/builder.css
@@ -37,6 +37,12 @@ main {
   overflow: auto;
 }
 
+main.select-template {
+  margin-top: 57px;
+  height: calc(100% - 57px);
+  padding-top: 20px;
+}
+
 .builder {
   position: relative;
   padding-top: 15px;
@@ -103,11 +109,6 @@ nav>.btn {
 .empty-state {
   padding: 40px 15px 0;
   text-align: center;
-}
-
-.change-template,
-.choose-template {
-  padding-top: 57px;
 }
 
 .change-template .panel {

--- a/interface.html
+++ b/interface.html
@@ -6,7 +6,7 @@
       <p>Loading the form builder... Please wait!</p>
     </div>
   </div>
-  <main>
+  <main v-bind:class="{ 'select-template': chooseTemplate }">
     <header>
       <p v-if="chooseTemplate">Template gallery</p>
       <p v-else>Configure your form</p>


### PR DESCRIPTION
Issue Reference: https://github.com/Fliplet/fliplet-studio/issues/3679

<img width="380" alt="screenshot 2019-01-14 at 11 52 17" src="https://user-images.githubusercontent.com/7046481/51111165-fe733b80-17f2-11e9-9495-a8cca5ed838a.png">
<img width="380" alt="screenshot 2019-01-14 at 11 52 37" src="https://user-images.githubusercontent.com/7046481/51111166-ff0bd200-17f2-11e9-84a4-a1286eef612b.png">
