### PR TITLE
Added conditional time reformatting

### DIFF
--- a/js/components/time.js
+++ b/js/components/time.js
@@ -14,6 +14,17 @@ Fliplet.FormBuilder.field('time', {
       this.$emit('_input', this.name, this.value);
     }
   },
+  beforeUpdate: function() {
+    /**
+     * if the passed time is in the HH:mm A format,
+     * that means that this must be an old record saved, 
+     * so we need to re-format it to the correct format which is accepted by the native html5 time input,
+     * which is HH:mm
+     */
+    if(moment(this.value, 'HH:mm A', true).isValid()){
+      this.value = moment(this.value, 'HH:mm A').format('HH:mm');
+    }
+  },
   mounted: function() {
     var $vm = this;
     if (!this.value) {


### PR DESCRIPTION
We had old time format entries in some data sources like: `11:36 PM`, while now, time is logged correctly as `23:36`.
This PR will handle old records and re-format them to the correct format if needed.
Ref.https://github.com/Fliplet/fliplet-studio/issues/3592