### PR TITLE
sort selected options for checkbox fields

### DIFF
--- a/js/components/checkbox.js
+++ b/js/components/checkbox.js
@@ -17,6 +17,20 @@ Fliplet.FormBuilder.field('checkbox', {
       ]
     }
   },
+  methods: {
+    updateValue: function () {
+      var $vm = this;
+
+      // Sort selected options by their index as a checkbox input option
+      var ordered = _.sortBy(this.value, function (val) {
+        return _.findIndex($vm.options, function (option) {
+          return option.id === val;
+        });
+      });
+
+      this.$emit('_input', this.name, ordered);
+    }
+  },
   computed: {
     isRequired: function () {
       return this.required && !this.value.length;


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/3743

> Verify the submitted value for checkbox fields are kept in the order as they appear in the form (rather than the order in which the user selected them)