### PR TITLE
Stops using FontAwesome for radio UI

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -425,16 +425,23 @@ html[dir="rtl"] .radio.radio-icon input[type="radio"] + label > span.check {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 0.9em;
-  color: #337ab7;
+  font-size: 0;
   -webkit-transform: scale(0);
   transform: scale(0);
   -webkit-transition: all 0.25s ease;
   transition: all 0.25s ease;
 }
 
+.radio.radio-icon input[type="radio"] + label span.check > i.fa:before {
+  content: '';
+  display: block;
+  background-color: #fff;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+}
+
 .radio.radio-icon input[type="radio"]:checked + label span.check > i.fa {
-  color: #FFF;
   -webkit-transform: scale(1);
   transform: scale(1);
 }


### PR DESCRIPTION
...in order to improve radio UI positioning -- because FontAwesome characters aren't consistent in how it's positioned due to character height, line height etc.

Ref. https://github.com/Fliplet/fliplet-studio/issues/3731

![image](https://user-images.githubusercontent.com/290733/55481291-f2d92900-5619-11e9-97de-c4a6c01f535c.png)
