### PR TITLE
better validation on input number

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -43,7 +43,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.input"] = Handlebar
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.number"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<input\n  type=\"number\"\n  class=\"form-control\"\n  v-model.trim=\"value\"\n  v-on:input=\"updateValue()\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n  :required=\"required\"\n  :pattern=\"pattern\"\n  :step=\"step\"\n  :min=\"min\"\n/>\n";
+    return "<input\n  type=\"number\"\n  class=\"form-control\"\n  v-model.trim=\"value\"\n  v-on:input=\"updateValue()\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n  :required=\"required\"\n  :pattern=\"pattern\"\n  :step=\"step\"\n  :min=\"min\"\n  v-on:keydown=\"verifyInput($event)\"\n/>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.paragraph"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -43,7 +43,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.input"] = Handlebar
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.number"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<input\n  type=\"number\"\n  class=\"form-control\"\n  v-model.trim=\"value\"\n  v-on:input=\"updateValue()\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n  :required=\"required\"\n  :pattern=\"pattern\"\n  :step=\"step\"\n  :min=\"min\"\n  v-on:keydown=\"verifyInput($event)\"\n/>\n";
+    return "<input\n  :type=\"inputType\"\n  class=\"form-control\"\n  v-model.trim=\"value\"\n  v-on:input=\"updateValue()\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n  :required=\"required\"\n  :pattern=\"pattern\"\n  :step=\"step\"\n  :min=\"min\"\n/>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.paragraph"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/components/number.js
+++ b/js/components/number.js
@@ -16,13 +16,11 @@ Fliplet.FormBuilder.field('number', {
   },
   methods: {
     updateValue: function () {
-      var $vm = this;
-
-      var rx = new RegExp(
+      var ensureNumberRx = new RegExp(
         this.positiveOnly ? '[^0-9\.,]' : '[^0-9\.,-]'
-      , 'g')
+      , 'g');
 
-      this.value = this.value.replace(rx, '');
+      this.value = this.value.replace(ensureNumberRx, '');
       this.$emit('_input', this.name, this.value);
     }
   },

--- a/js/components/number.js
+++ b/js/components/number.js
@@ -14,6 +14,47 @@ Fliplet.FormBuilder.field('number', {
       default: 0
     }
   },
+  methods: {
+    verifyInput: function(event) {
+      if (!event) {
+        return;
+      }
+
+      var code = event.which ? event.which : event.keyCode;
+
+      // Do not allow dot/comma characters if settings are not allowing decimals
+      if ([188, 190].indexOf(code) !== -1) {
+        if (parseInt(this.decimals, 10) === 0 || this.value.match(/\.,/)) {
+          event.preventDefault();
+        }
+
+        return;
+      }
+
+      // Allow minus sign only as first character given the input
+      // is allowing negative numbers.
+      if (code === 189) {
+        if (this.positiveOnly || this.value.length) {
+          event.preventDefault();
+        }
+
+        return;
+      }
+
+      // Allow 0-9 numbers
+      if (code >= 48 && code <= 57) {
+        return true;
+      }
+
+      // Allow modifiers keys, delete, return and arrows
+      if ([13, 16, 17, 18, 8, 37, 38, 39, 40, 91].indexOf(code) !== -1) {
+        return;
+      }
+
+      // Don't allow other inputs
+      event.preventDefault();
+    }
+  },
   computed: {
     pattern: function () {
       if (this.positiveOnly) {

--- a/js/components/number.js
+++ b/js/components/number.js
@@ -17,7 +17,7 @@ Fliplet.FormBuilder.field('number', {
   methods: {
     updateValue: function () {
       var ensureNumberRx = new RegExp(
-        this.positiveOnly ? '[^0-9\.,]' : '[^0-9\.,-]'
+        this.positiveOnly ? '[^0-9\.]' : '[^0-9\.-]'
       , 'g');
 
       this.value = this.value.replace(ensureNumberRx, '');

--- a/js/components/number.js
+++ b/js/components/number.js
@@ -15,47 +15,21 @@ Fliplet.FormBuilder.field('number', {
     }
   },
   methods: {
-    verifyInput: function(event) {
-      if (!event) {
-        return;
-      }
+    updateValue: function () {
+      var $vm = this;
 
-      var code = event.which ? event.which : event.keyCode;
+      var rx = new RegExp(
+        this.positiveOnly ? '[^0-9\.,]' : '[^0-9\.,-]'
+      , 'g')
 
-      // Do not allow dot/comma characters if settings are not allowing decimals
-      if ([188, 190].indexOf(code) !== -1) {
-        if (parseInt(this.decimals, 10) === 0 || this.value.match(/\.,/)) {
-          event.preventDefault();
-        }
-
-        return;
-      }
-
-      // Allow minus sign only as first character given the input
-      // is allowing negative numbers.
-      if (code === 189) {
-        if (this.positiveOnly || this.value.length) {
-          event.preventDefault();
-        }
-
-        return;
-      }
-
-      // Allow 0-9 numbers
-      if (code >= 48 && code <= 57) {
-        return true;
-      }
-
-      // Allow modifiers keys, delete, return and arrows
-      if ([13, 16, 17, 18, 8, 37, 38, 39, 40, 91].indexOf(code) !== -1) {
-        return;
-      }
-
-      // Don't allow other inputs
-      event.preventDefault();
+      this.value = this.value.replace(rx, '');
+      this.$emit('_input', this.name, this.value);
     }
   },
   computed: {
+    inputType: function () {
+      return this.positiveOnly ? 'number' : 'text';
+    },
     pattern: function () {
       if (this.positiveOnly) {
         return '\\d*';

--- a/templates/components/number.build.hbs
+++ b/templates/components/number.build.hbs
@@ -1,5 +1,5 @@
 <input
-  type="number"
+  :type="inputType"
   class="form-control"
   v-model.trim="value"
   v-on:input="updateValue()"
@@ -10,5 +10,4 @@
   :pattern="pattern"
   :step="step"
   :min="min"
-  v-on:keydown="verifyInput($event)"
 />

--- a/templates/components/number.build.hbs
+++ b/templates/components/number.build.hbs
@@ -10,4 +10,5 @@
   :pattern="pattern"
   :step="step"
   :min="min"
+  v-on:keydown="verifyInput($event)"
 />


### PR DESCRIPTION
### When all numbers are allowed:

- the input type will be set to `text`
- the input will only allow numbers, `-` and `.`

### When positive numbers only are allowed

- the input type will be set to `number`
- the input will only allow numbers and `.` (this is for web only)