### PR TITLE
Force form update on entry load

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -415,10 +415,12 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
             $vm.fields = getFields();
             $vm.isLoading = false;
+            $vm.$forceUpdate();
           }).catch(function (err) {
             var error = Fliplet.parseError(err);
             $vm.error = error;
             $vm.isLoading = false;
+            $vm.$forceUpdate();
 
             Fliplet.UI.Toast.error(error, {
               message: 'Unable to load entry'


### PR DESCRIPTION
As per GIF below, fixes an issue where the form does not correctly reload its data (both UI state and inputs) after fetching an entry to update.

![gif](https://cl.ly/96f46060ca2d/Screen%252520Recording%2525202019-05-15%252520at%25252005.50%252520PM.gif)