### PR TITLE
Hide data source settings

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -135,7 +135,7 @@
                 <span class="icon fa fa-chevron-down"></span>
                 <span class="select-value-proxy">-- Select a data source</span>
               </label>
-              <small v-if="manageDataBtn"><a href="#" v-on:click.prevent="manageDataSource(settings.dataSourceId)">Edit data source</a></small>
+              <small v-if="showDataSourceSettings"><a href="#" v-on:click.prevent="manageDataSource(settings.dataSourceId)">Edit data source</a></small>
             </div>
 
             <h3>Submission</h3>
@@ -144,7 +144,7 @@
                 <label>When the form is submitted...</label>
               </div>
               <div>
-                <div class="checkbox checkbox-icon">
+                <div class="checkbox checkbox-icon" v-if="showDataSourceSettings">
                   <input type="checkbox" id="save_datasource" name="dataStore" v-model="settings.dataStore" value="dataSource">
                   <label for="save_datasource">
                     <span class="check"><i class="fa fa-check"></i></span> Add new submissions to a data source
@@ -210,7 +210,7 @@
                   </div>
                 </div>
 
-                <div class="checkbox checkbox-icon">
+                <div class="checkbox checkbox-icon" v-if="showDataSourceSettings">
                   <input type="checkbox" id="edit_datasource" name="dataStore" v-model="settings.dataStore" value="editDataSource">
                   <label for="edit_datasource">
                     <span class="check"><i class="fa fa-check"></i></span> Update existing entries in a data source

--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -81,7 +81,7 @@ function generateFormDefaults(data) {
     fields: [],
     offline: true,
     redirect: false,
-    dataStore: ['dataSource'],
+    dataStore: [],
     onSubmit: [],
     template: false,
     saveProgress: true,
@@ -123,8 +123,8 @@ var app = new Vue({
       toggleTemplatedEmailAdd: formSettings.onSubmit.indexOf('templatedEmailAdd') > -1,
       toggleTemplatedEmailEdit: formSettings.onSubmit.indexOf('templatedEmailEdit') > -1,
       toggleGenerateEmail: formSettings.onSubmit.indexOf('generateEmail') > -1,
-      showExtraAdd: formSettings.dataStore.indexOf('dataSource') > -1,
-      showExtraEdit: formSettings.dataStore.indexOf('editDataSource') > -1,
+      showExtraAdd: formSettings.dataSourceId && formSettings.dataStore.indexOf('dataSource') > -1,
+      showExtraEdit: formSettings.dataSourceId && formSettings.dataStore.indexOf('editDataSource') > -1,
       userData: {},
       defaultEmailSettings: {
         subject: '',
@@ -140,7 +140,7 @@ var app = new Vue({
       emailTemplateEdit: formSettings.emailTemplateEdit || undefined,
       generateEmailTemplate: formSettings.generateEmailTemplate || undefined,
       conflictWarning: formSettings.dataStore.indexOf('dataSource') > -1 && formSettings.autobindProfileEditing ? true : false,
-      manageDataBtn: formSettings.dataSourceId && formSettings.dataSourceId !== '' ? true : false,
+      showDataSourceSettings: !!formSettings.dataSourceId,
       organizationName: '',
       isPreviewing: formSettings.previewingTemplate !== '',
       editor: undefined
@@ -270,7 +270,7 @@ var app = new Vue({
       }).then(function(ds) {
         $vm.dataSources.push(ds);
         $vm.settings.dataSourceId = ds.id;
-        $vm.manageDataBtn = true;
+        $vm.showDataSourceSettings = true;
       });
     },
     manageDataSource: function(dataSourceId) {
@@ -687,7 +687,13 @@ var app = new Vue({
       changeSelectText();
     },
     'settings.dataSourceId': function(value) {
-      this.manageDataBtn = value && value !== '' && value !== 'new';
+      this.showDataSourceSettings = value && value !== 'new';
+
+      if (!this.showDataSourceSettings) {
+        this.showExtraAdd = false;
+        this.showExtraEdit = false;
+        this.settings.dataStore = [];
+      }
 
       if (value === 'new') {
         this.createDataSource();
@@ -885,6 +891,10 @@ var app = new Vue({
     window.linkProvider = null;
     var $vm = this;
     $vm.settings.name = $vm.settings.name || 'Untitled form';
+
+    if (!$vm.showDataSourceSettings) {
+      $vm.settings.dataStore = [];
+    }
 
     if (this.chooseTemplate) {
       Fliplet.Studio.emit('widget-save-label-update', {


### PR DESCRIPTION
@squallstar 
Form settings related to a data source should only be available when a data source has been selected

No ref to the Github issue

![1](https://user-images.githubusercontent.com/1763029/59865340-74c32d80-9391-11e9-883b-be340a1b8949.jpg)
![2](https://user-images.githubusercontent.com/1763029/59865348-7987e180-9391-11e9-8c86-d69b96b8cae1.jpg)

