### PR TITLE
#65 The selected file is saved in the "Attach a file" field after submitting the form #3787 #3786

### DIFF
--- a/js/components/file.js
+++ b/js/components/file.js
@@ -40,6 +40,9 @@ Fliplet.FormBuilder.field('file', {
       return _.map(this.selectedFiles, 'name').join(', ');
     }
   },
+  destroyed: function() {
+    this.selectedFiles.length = 0;
+  },
   methods: {
     updateValue: function() {
       var $vm = this;


### PR DESCRIPTION
@squallstar 

Added destroyed lifecycle method in file.js.
P.S. I know that using 'length = 0' for emptying array is not the best practice, but other methods do not work.  

ref Fliplet/fliplet-studio#3786
ref Fliplet/fliplet-studio#3787

![task65-upplabs](https://user-images.githubusercontent.com/52824207/61361013-4c432c00-a888-11e9-8bdf-808e6334eb35.gif)
