### PR TITLE
Date picker UI render is clipped on the viewport edges

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -852,7 +852,7 @@ form hr {
 
 .datepicker table tr td,
 .datepicker table tr th {
-  min-width: 44px;
+  min-width: 38px;
 }
 
 /* TinyMCE source code area */


### PR DESCRIPTION
@squallstar 
ref https://github.com/Fliplet/fliplet-studio/issues/3239
![Снимок экрана 2019-07-22 в 13 22 39](https://user-images.githubusercontent.com/52824216/61625932-9c553080-ac84-11e9-84aa-6fe3c04e798a.png)
![Снимок экрана 2019-07-22 в 13 22 49](https://user-images.githubusercontent.com/52824216/61625951-a414d500-ac84-11e9-9249-dcd229d2cff6.png)

