### PR TITLE
Fixes an issue where Rich Text field wasn't submitting when there's a Datepicker in the same form

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -474,7 +474,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
           /**
            * When we try to submit a form in Edge or IE11 and use components date picker and rich text
            * (only in this sequence) we could saw that rich text textarea become empty but there was no 
-           * message that we successfully submited the form. That was because Vue wasn't updating view.
+           * message that we successfully submitted the form. That was because Vue wasn't updating view.
            * $forceUpdate solve this issue. 
            */
           $vm.$forceUpdate();

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -471,6 +471,13 @@ Fliplet.Widget.instance('form-builder', function(data) {
           $vm.isSent = true;
           $vm.isSending = false;
           $vm.reset(false);
+          /**
+           * When we try to submit a form in Edge or IE11 and use components date picker and rich text
+           * (only in this sequence) we could saw that rich text textarea become empty but there was no 
+           * message that we successfully submited the form. That was because Vue wasn't updating view.
+           * $forceUpdate solve this issue. 
+           */
+          $vm.$forceUpdate();
 
           $vm.loadEntryForUpdate();
         }, function(err) {


### PR DESCRIPTION
@squallstar @tonytlwu 

**Fixed behavior:**
When you use the form with a date picker and rich text (only in this sequence) form doesn't submit in IE11 and Edge. Now it submits and shows the correct message.

ref Fliplet/fliplet-studio#4790

![richTextForm-Submit-Fix](https://user-images.githubusercontent.com/53430352/62633596-13edb580-b93d-11e9-9141-3a1f0cdd5eef.gif)