### PR TITLE
Changed place where TinyMCE is initiated

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -798,6 +798,7 @@ var app = new Vue({
     'section': function(value) {
       var $vm = this;
       if (value === 'settings') {
+        $vm.setupCodeEditor();
         changeSelectText();
       }
     },
@@ -1038,8 +1039,6 @@ var app = new Vue({
     Fliplet.User.fetch().then(function(user) {
       $vm.userData = user;
     });
-
-    $vm.setupCodeEditor();
   },
   updated: function() {
     var $vm = this;


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4827

## Description
Changed place where TinyMCE is initiated. Now it initiates when the user clicks on the Setting button. Now should work as expected.

## Screenshots/screencasts
![tinyMCE demo](https://user-images.githubusercontent.com/52824207/63269607-3669c200-c29f-11e9-9206-0928fb90350c.gif)


## Backward compatibility
This change is fully backward compatible.