### PR TITLE
Added tinymce destroyed method

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -800,6 +800,8 @@ var app = new Vue({
       if (value === 'settings') {
         $vm.setupCodeEditor();
         changeSelectText();
+      } else {
+        tinymce.remove();
       }
     },
     'settings.dataStore': function(value) {


### PR DESCRIPTION
@tonytlwu @squallstar 

## Issue
Fliplet/fliplet-studio#4827

## Description
Added destroyed method for TinyMCE after the user leaves the settings tab. Now bug should not occur.

## Screenshots/screencasts
![tinymce demo 1](https://user-images.githubusercontent.com/52824207/63501942-36eb9e00-c4d5-11e9-8ddf-94b999a9e0b7.gif)

## Backward compatibility
This change is fully backward compatible.