### PR TITLE
Stop adding br tag when line break appears

### DIFF
--- a/js/components/paragraph.js
+++ b/js/components/paragraph.js
@@ -15,7 +15,7 @@ Fliplet.FormBuilder.field('paragraph', {
   },
   computed: {
     htmlValue: function() {
-      return this.value.replace(/\r?\n/g, '<br />');
+      return this.value;
     }
   }
 });


### PR DESCRIPTION
@tonytlwu @squallstar 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/4935

## Description
Stop adding br tag when line break appears

## Screenshots/screencasts
![issue-4935](https://user-images.githubusercontent.com/53430352/64776063-31c3c100-d560-11e9-9b19-f2e5f336aea3.gif)


## Backward compatibility

This change is fully backward compatible.