### PR TITLE
Support for reading list of options on a field and getting the field vue instance

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -726,6 +726,10 @@ Fliplet.Widget.instance('form-builder', function(data) {
                 }
               },
               options: function (values) {
+                if (typeof values === 'undefined') {
+                  return field.options;
+                }
+
                 if (!Array.isArray(values)) {
                   throw new Error('Options must be an array');
                 }
@@ -747,7 +751,8 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
                 // Update live field
                 field.options = options;
-              }
+              },
+              instance: field
             };
           }
         });


### PR DESCRIPTION
```js
// get
var options = form.field('foo').options()

// set 
form.field('foo').options([1,2,3])

// reference $vm instance (follows same pattern as form.instance)
form.field('foo').instance
```