### PR TITLE
Support for triggering change events when the value of a field changes via field.set

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -726,6 +726,10 @@ Fliplet.Widget.instance('form-builder', function(data) {
                 }
               },
               options: function (values) {
+                if (typeof values === 'undefined') {
+                  return field.options;
+                }
+
                 if (!Array.isArray(values)) {
                   throw new Error('Options must be an array');
                 }
@@ -747,7 +751,8 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
                 // Update live field
                 field.options = options;
-              }
+              },
+              instance: field
             };
           }
         });

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -644,8 +644,14 @@ Fliplet.Widget.instance('form-builder', function(data) {
                   return field.value;
                 }
 
+                const hasChanged = field.value !== value;
+                
                 field.value = value;
                 debouncedUpdate();
+
+                if (hasChanged) {
+                  $form.triggerChange(field.name, field.value);
+                }
               },
               set: function (data) {
                 var result;

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -703,7 +703,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
                     value = '';
                   }
 
-                  const hasChanged = field.value !== value;
+                  var hasChanged = field.value !== value;
 
                   field.value = value;
                   debouncedUpdate();

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -644,14 +644,8 @@ Fliplet.Widget.instance('form-builder', function(data) {
                   return field.value;
                 }
 
-                const hasChanged = field.value !== value;
-                
                 field.value = value;
                 debouncedUpdate();
-
-                if (hasChanged) {
-                  $form.triggerChange(field.name, field.value);
-                }
               },
               set: function (data) {
                 var result;
@@ -709,8 +703,14 @@ Fliplet.Widget.instance('form-builder', function(data) {
                     value = '';
                   }
 
+                  const hasChanged = field.value !== value;
+
                   field.value = value;
                   debouncedUpdate();
+
+                  if (hasChanged) {
+                    $form.triggerChange(field.name, field.value);
+                  }
                 });
               },
               get: function() {


### PR DESCRIPTION
Changes made via `field.set()` will now trigger `field.change(fn)` if the value has changed.