### PR TITLE
Clear button now works correctly

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -214,6 +214,8 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
         Fliplet.FormBuilder.emit('reset');
         this.$emit('reset');
+        
+        $vm.triggerBlurEventOnInputs();
       },
       onError: function (fieldName, error) {
         if (!error) {
@@ -475,9 +477,9 @@ Fliplet.Widget.instance('form-builder', function(data) {
           $vm.reset(false);
           /**
            * When we try to submit a form in Edge or IE11 and use components date picker and rich text
-           * (only in this sequence) we could saw that rich text textarea become empty but there was no 
+           * (only in this sequence) we could saw that rich text textarea become empty but there was no
            * message that we successfully submitted the form. That was because Vue wasn't updating view.
-           * $forceUpdate solve this issue. 
+           * $forceUpdate solve this issue.
            */
           $vm.$forceUpdate();
 


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5221

## Description
Added force blur on all fields after clear which saves them.

## Screenshots/screencasts
![clear-fix](https://user-images.githubusercontent.com/52824207/68214385-04d2de00-ffe6-11e9-8cf4-63b7dec35c8b.gif)

## Backward compatibility
This change is fully backward compatible.