### PR TITLE
User not can enter value for checkbox in string form, dublicate value will be removed 

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -654,6 +654,16 @@ Fliplet.Widget.instance('form-builder', function(data) {
               },
               set: function (data) {
                 var result;
+                
+                if (field._type === 'flCheckbox') {
+                  if (typeof data === 'string') {
+                    data = data.split(',');
+                  }
+
+                  if (_.isArray(data)) {
+                    data = _.uniq(data);
+                  }
+                }
 
                 if (typeof data === 'function') {
                   data = { source: 'function', key: data };


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5222
Fliplet/fliplet-studio#5227

## Description
If the value set for checkbox it converts the value to array if it is a string and removes duplicates if it is an array.

## Screenshots/screencasts
5222
![5222](https://user-images.githubusercontent.com/52824207/68379694-0a036a80-0157-11ea-8220-71b9f2ffe009.gif)

5227
![5227](https://user-images.githubusercontent.com/52824207/68379700-0c65c480-0157-11ea-806b-db7b05e5f642.gif)

## Backward compatibility
This change is fully backward compatible.