### PR TITLE
If user changes options using setting code, previously selected value will be cleared if they do not correspont to new options

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -757,6 +757,19 @@ Fliplet.Widget.instance('form-builder', function(data) {
                   return { id: option };
                 });
 
+                if (field.value.length && field._type === 'flCheckbox') {
+                  var selectedValues = _.difference(field.value, values);
+
+                  field.value = selectedValues.length ? [] : field.value;
+
+                } else if (field.value && (field._type === 'flRadio' || field._type === 'flSelect')) {
+                  var selectedValueInOptions = _.some(values, function(option) {
+                    return option === field.value;
+                  });
+
+                  field.value = selectedValueInOptions ? field.value : '';
+                }
+
                 // Update options in field definition so they are kept between renderings
                 _.find(data.fields, { name: field.name }).options = options;
 

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -757,17 +757,22 @@ Fliplet.Widget.instance('form-builder', function(data) {
                   return { id: option };
                 });
 
-                if (field.value.length && field._type === 'flCheckbox') {
-                  var selectedValues = _.difference(field.value, values);
+                if (!_.isEmpty(field.value)) {
+                  switch (field._type) {
+                    case 'flCheckbox':
+                      var selectedValues = _.difference(field.value, values);
 
-                  field.value = selectedValues.length ? [] : field.value;
+                      field.value = selectedValues.length ? [] : field.value;
+                      break;
+                    case 'flRadio':
+                    case 'flSelect':
+                      var selectedValueInOptions = _.some(values, function(option) {
+                        return option === field.value;
+                      });
 
-                } else if (field.value && (field._type === 'flRadio' || field._type === 'flSelect')) {
-                  var selectedValueInOptions = _.some(values, function(option) {
-                    return option === field.value;
-                  });
-
-                  field.value = selectedValueInOptions ? field.value : '';
+                      field.value = selectedValueInOptions ? field.value : '';
+                      break;
+                  }
                 }
 
                 // Update options in field definition so they are kept between renderings


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5200

## Description
Added check to values when user setting options using code.

## Screenshots/screencasts
![set options demo](https://user-images.githubusercontent.com/52824207/68461322-99ba1f00-0212-11ea-90f5-f7ec4e643446.gif)

## Backward compatibility
This change is fully backward compatible.