### PR TITLE
Current page is not added to link provider dropdown

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -679,10 +679,14 @@ var app = new Vue({
     },
     initLinkProvider: function() {
       var $vm = this;
+      var page = Fliplet.Widget.getPage();
+      var omitPages = page ? [page.id] : [];
+
       var action = $.extend(true, {
         action: 'screen',
         page: '',
         transition: 'slide.left',
+        omitPages: omitPages,
         options: {
           hideAction: true
         }


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
Fliplet/fliplet-studio#4498

## Description
Added omit page property.

## Screenshots/screencasts
![omit page demo ](https://user-images.githubusercontent.com/52824207/68747871-1890cc80-0604-11ea-9dbb-005fe43ec014.gif)

## Backward compatibility
This change is fully backward compatible.