### PR TITLE
Old buttons fields now have label

### DIFF
--- a/js/components/buttons.js
+++ b/js/components/buttons.js
@@ -32,5 +32,8 @@ Fliplet.FormBuilder.field('buttons', {
       type: String,
       default: 'reset'
     }
+  },
+  mounted: function() {
+    this.label = this.label || this.name;
   }
 });


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5313

## Description
Added mounted lifecycle hook that assigns name value to label if there is no value.

## Screenshots/screencasts
<img width="1141" alt="buttons demo" src="https://user-images.githubusercontent.com/52824207/69140217-bedc4680-0aca-11ea-9fb8-1360fc642f8e.png">

## Backward compatibility
This change is fully backward compatible.