### PR TITLE
Clear button now clears progress correctly

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -219,10 +219,9 @@ Fliplet.Widget.instance('form-builder', function(data) {
           $vm.triggerChange(field.name, field.value);
         });
 
+        localStorage.removeItem(progressKey);
         Fliplet.FormBuilder.emit('reset');
         this.$emit('reset');
-        
-        $vm.triggerBlurEventOnInputs();
       },
       onError: function (fieldName, error) {
         if (!error) {
@@ -663,7 +662,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
               },
               set: function (data) {
                 var result;
-                
+
                 if (field._type === 'flCheckbox') {
                   if (typeof data === 'string') {
                     data = data.split(',');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5221

## Description
Now when the user clicks on a clear button local storage gets removed.

## Screenshots/screencasts
![clear-demo](https://user-images.githubusercontent.com/52824207/69619774-cbb9e680-1044-11ea-84db-704c77641aa1.gif)

## Backward compatibility
This change is fully backward compatible.