### PR TITLE
Form progress is saved after it's updated via field.set() or field.val()

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -221,7 +221,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
         Fliplet.FormBuilder.emit('reset');
         this.$emit('reset');
-        
+
         $vm.triggerBlurEventOnInputs();
       },
       onError: function (fieldName, error) {
@@ -617,6 +617,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
       this.loadEntryForUpdate().then(function () {
         var debouncedUpdate = _.debounce(function () {
           $form.$forceUpdate();
+          $vm.saveProgress();
         }, 10);
 
         // This data is available through "Fliplet.FormBuilder.get()"
@@ -663,7 +664,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
               },
               set: function (data) {
                 var result;
-                
+
                 if (field._type === 'flCheckbox') {
                   if (typeof data === 'string') {
                     data = data.split(',');


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5277

## Description
Added function that saves progress to local storage after updating via field.set() or field.val().

## Screenshots/screencasts
![save-demo ](https://user-images.githubusercontent.com/52824207/69634426-d54e4900-105a-11ea-9f3b-57b2dbc24a3c.gif)

## Backward compatibility
This change is fully backward compatible.