### PR TITLE
Invalid options are removed when setting dropdown field options

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -136,7 +136,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
               } else if (typeof img === 'string') {
                 field.value.push(img);
               }
-    
+
               field.value = field.value.map(function(url) {
                 return Fliplet.Media.authenticate(url);
               });
@@ -165,7 +165,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
                     inOptions.push(inOption);
                   }
                 });
-                
+
                 field.value = inOptions.length ? _.uniqWith(entry.data[field.name], _.isEqual) : [];
               } else {
                 field.value = [];
@@ -820,6 +820,12 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
                 if (!Array.isArray(values)) {
                   throw new Error('Options must be an array');
+                }
+
+                if (field._type === 'flSelect') {
+                  _.remove(values, function(val) {
+                    return val === null  || val === undefined || val.trim() === '';
+                  });
                 }
 
                 var options = values.map(function (option) {

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -824,7 +824,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
                 if (field._type === 'flSelect') {
                   _.remove(values, function(val) {
-                    return val === null  || val === undefined || val.trim() === '';
+                    return val === null || val === undefined || val.trim() === '';
                   });
                 }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5448

## Description
The invalid options are removed before the options are set.

## Screenshots/screencasts
![dropdown options demo](https://user-images.githubusercontent.com/52824207/70910520-8c196580-2018-11ea-98ec-70f1b86f9eee.gif)

## Backward compatibility
This change is fully backward compatible.