### PR TITLE
don't update fields when value is undefined

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -117,6 +117,10 @@ Fliplet.Widget.instance('form-builder', function(data) {
         if (entry && entry.data && field.populateOnUpdate !== false) {
           var fieldData = entry.data[field.name];
 
+          if (typeof fieldData === 'undefined') {
+            return; // do not update the field value
+          }
+
           switch (field._type) {
             case 'flDate':
               var regexDateFormat = /([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))/;


### PR DESCRIPTION
- Restores behaviour to prior than 971a024 (line https://github.com/Fliplet/fliplet-widget-form-builder/commit/971a0240b3a98450d0f2f99ec56ba9918007f232#diff-aab0ddc8ded3b82294a8d0537f15e112L117)

ref https://github.com/Fliplet/fliplet-studio/issues/5484