### PR TITLE
Dropdown now accepts number as options

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -840,8 +840,9 @@ Fliplet.Widget.instance('form-builder', function(data) {
                 }
 
                 if (field._type === 'flSelect') {
+                  // remove all invalid options
                   _.remove(values, function(val) {
-                    return val === null || val === undefined || val.trim() === '';
+                    return !(_.isObject(val) || _.isNumber(val) || (_.isString(val) && val.trim()));
                   });
                 }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#5448

## Description
The invalid options are removed before the options are set.

## Screenshots/screencasts
![dropdown-fix](https://user-images.githubusercontent.com/52824207/71667569-5a213680-2d6e-11ea-8b09-28322580c426.gif)

## Backward compatibility
This change is fully backward compatible.