### PR TITLE
Border properties now affect rich text field

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -761,6 +761,10 @@ html[dir="rtl"] .radio.radio-icon input[type="radio"] + label > span.check {
 /* WYSIWYG FIELD */
 
 .form-group .mce-tinymce {
+  border: none;
+}
+
+.form-group .mce-tinymce > .mce-container-body.mce-stack-layout {
   border: 1px solid #ccc;
   border-radius: 4px;
   overflow: hidden;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/4724

## Description
Updated rich text styling.

## Screenshots/screencasts
![form-rich-text](https://user-images.githubusercontent.com/52824207/73848042-05bb1c00-4830-11ea-908d-7b54c8d0a6d7.PNG)

## Backward compatibility
This change is fully backward compatible.

## Notes
Goes together with this PR https://github.com/Fliplet/fliplet-theme-default/pull/105