### PR TITLE
fixed wrong variable name

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -573,7 +573,7 @@ var app = new Vue({
         }
 
         return Fliplet.DataSources.update(dataSourceId, {
-          columns: newColumns,
+          columns: columns,
           hooks: ds.hooks
         });
       });


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/5775

---

Saving a form was incorrectly removing from the data source columns all columns not contained in the list of fields of the form to be saved.

This is now fixed so that a form never removes existing columns from a data source.