### PR TITLE
Removed unnecessary box-shadow property

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -762,6 +762,9 @@ html[dir="rtl"] .radio.radio-icon input[type="radio"] + label > span.check {
 
 .form-group .mce-tinymce {
   border: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
 }
 
 .form-group .mce-tinymce > .mce-container-body.mce-stack-layout {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
Fliplet/fliplet-studio#4724

## Description
Removed unnecessary box-shadow property.

## Screenshots/screencasts
Look without setting border.
![removed-box-shadow](https://user-images.githubusercontent.com/52824207/74826181-d4ece380-5313-11ea-8f9a-ba46110a5909.PNG)

With setting border
![rich-text](https://user-images.githubusercontent.com/52824207/74826186-d7e7d400-5313-11ea-8846-b9654fff671c.PNG)

## Backward compatibility
This change is fully backward compatible.