### PR TITLE
Date and calendar icons are now visible on ios13

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -250,7 +250,7 @@ textarea.form-control {
   text-align: center;
   background-color: transparent;
   border: none;
-  z-index: 4;
+  z-index: 10;
 }
 
 .input-group-addon:first-child {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5325

## Description
Changed z-index value.

## Screenshots/screencasts
![photo_2020-02-21_14-14-25](https://user-images.githubusercontent.com/52824207/75033847-7e6adb00-54b4-11ea-8f25-f33efa7cd4ae.jpg)

## Backward compatibility
This change is fully backward compatible.