### PR TITLE
User now can upload recently deleted file

### DIFF
--- a/js/components/file.js
+++ b/js/components/file.js
@@ -103,6 +103,9 @@ Fliplet.FormBuilder.field('file', {
 
       this.validateValue();
 
+      // this is used to trigger onChange event even if user deletes and than uploads same file
+      this.$refs.fileInput.value = null;
+
       $vm.value.splice(index, 1);
 
       $vm.value.forEach(function (file, index) {

--- a/js/components/image.js
+++ b/js/components/image.js
@@ -55,7 +55,7 @@ Fliplet.FormBuilder.field('image', {
   mounted: function () {
      this.drawImagesAfterInit();
   },
-  updated:function () {
+  updated: function () {
     this.drawImagesAfterInit();
   },
   destroyed: function() {
@@ -64,6 +64,9 @@ Fliplet.FormBuilder.field('image', {
   methods: {
     removeImage: function(index) {
       var $vm = this;
+
+      // this is used to trigger onChange event even if user deletes and than uploads same image
+      $vm.$refs.imageInput.value = null;
 
       $vm.value.splice(index, 1);
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5415

## Description
The issue was that onChange event was not triggered when the user uploads same image.

## Screenshots/screencasts
![files-fix](https://user-images.githubusercontent.com/52824207/75050526-cf8ac700-54d4-11ea-8164-a5bf2464a479.gif)

## Backward compatibility
This change is fully backward compatible.