### PR TITLE
Doesn't allow a user to input incorrect URL

### DIFF
--- a/js/components/url.js
+++ b/js/components/url.js
@@ -9,7 +9,8 @@ Fliplet.FormBuilder.field('url', {
   validations: function () {
     var rules = {
       value: {
-        url: window.validators.helpers.regex('', /(?:^|[^@\.\w-])([a-z0-9]+:\/\/)?(\w(?!ailto:)\w+:\w+@)?([\w.-]+\.[a-z]{2,32})(:[0-9]+)?(\/.*)?(?=$|[^@\.\w-])/i)
+        // URL regex taken form https://www.regextester.com/94502
+        url: window.validators.helpers.regex('', /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/i)
       }
     };
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5405

## Description
Doesn't allow a user to input incorrect URL

## Screenshots/screencasts
https://share.getcloudapp.com/lluy40Rg

## Backward compatibility

This change is fully backward compatible.

## Notes
This regex works with all domains listed in this [here](http://data.iana.org/TLD/tlds-alpha-by-domain.txt).