### PR TITLE
Make validation work right away as user start to input something into the URL field

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -87,7 +87,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.title"] = Handlebar
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.url"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<input\n  type=\"url\"\n  class=\"form-control\"\n  v-model.trim.lazy=\"value\"\n  v-on:blur=\"updateValue()\"\n  v-on:input=\"onInput($event)\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n/>\n<p class=\"text-danger\" v-if=\"$v.value.url === false && $v.value.$dirty\">The input is not a valid URL.</p>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">Field is required.</p>\n";
+    return "<input\n  type=\"url\"\n  class=\"form-control\"\n  v-model.trim.lazy=\"value\"\n  v-on:focus=\"updateValue()\"\n  v-on:input=\"onInput($event)\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n/>\n<p class=\"text-danger\" v-if=\"$v.value.url === false && $v.value.$dirty\">The input is not a valid URL.</p>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">Field is required.</p>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.wysiwyg"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/templates/components/url.build.hbs
+++ b/templates/components/url.build.hbs
@@ -2,7 +2,7 @@
   type="url"
   class="form-control"
   v-model.trim.lazy="value"
-  v-on:blur="updateValue()"
+  v-on:focus="updateValue()"
   v-on:input="onInput($event)"
   :name="name"
   :id="name"


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5405

## Description
Make validation work right away as user start to input something into the URL field

## Screenshots/screencasts
https://share.getcloudapp.com/kpuYw4Ge

## Backward compatibility

This change is fully backward compatible.

## Notes
Changed event from blur to focus so that validation rule starts to work right away but not waiting element to be blurred.