### PR TITLE
Clearing form fields when clicking on the "Clear" button

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -268,7 +268,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
             value = value.slice(0);
           }
 
-          field.value = value;
+          field.value = '';
           $vm.triggerChange(field.name, field.value);
         });
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5514

## Description
Clearing form fields when clicking on the "Clear" button

## Screenshots/screencasts
https://share.getcloudapp.com/7KuRpbdO

## Backward compatibility

This change is fully backward compatible.

## Notes
As I tested I couldn't see any effect on other parts of the app. Could you please verify this.