### PR TITLE
Organization form template description is displayed correctly

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -298,6 +298,9 @@ var app = new Vue({
       if (initial) {
         // Untick "Set template" checkbox when creating a form from Template
         $vm.settings.template = false;
+
+        // Clear the default description
+        $vm.settings.description = '';
       }
 
       if (this.settings.onSubmit.indexOf('templatedEmailAdd') > -1) {
@@ -308,10 +311,6 @@ var app = new Vue({
       }
       if (this.settings.onSubmit.indexOf('generateEmail') > -1) {
         this.settings.generateEmailTemplate = this.generateEmailTemplate || this.defaultEmailSettingsForCompose;
-      }
-
-      if (!initial) {
-        $vm.settings.description = $vm.editor.getContent();
       }
 
       $vm.settings.name = $vm.settings.displayName;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5412

## Description
We clear the default description only when selecting the template. Afterwards if user sets new description it will be saved correctly.

## Screenshots/screencasts
![form-template](https://user-images.githubusercontent.com/52824207/76408880-55908400-6396-11ea-9dc9-2169622a59e4.PNG)

## Backward compatibility
This change is fully backward compatible.