### PR TITLE
Email field has right keyboard on native devices

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -15,7 +15,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.date"] = Handlebars
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.email"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<input\n  type=\"text\"\n  class=\"form-control\"\n  v-model.trim.lazy=\"value\"\n  v-on:blur=\"updateValue()\"\n  v-on:input=\"onInput($event)\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n/>\n<p class=\"text-danger\" v-if=\"$v.value.email === false && $v.value.$dirty\">The input is not a valid email address.</p>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">Field is required.</p>\n";
+    return "<input\n  type=\"email\"\n  class=\"form-control\"\n  v-model.trim.lazy=\"value\"\n  v-on:blur=\"updateValue()\"\n  v-on:input=\"onInput($event)\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n  autocomplete=\"new-password\"\n/>\n<p class=\"text-danger\" v-if=\"$v.value.email === false && $v.value.$dirty\">The input is not a valid email address.</p>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">Field is required.</p>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.field"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/templates/components/email.build.hbs
+++ b/templates/components/email.build.hbs
@@ -1,5 +1,5 @@
 <input
-  type="text"
+  type="email"
   class="form-control"
   v-model.trim.lazy="value"
   v-on:blur="updateValue()"
@@ -7,6 +7,7 @@
   :name="name"
   :id="name"
   :placeholder="placeholder"
+  autocomplete="new-password"
 />
 <p class="text-danger" v-if="$v.value.email === false && $v.value.$dirty">The input is not a valid email address.</p>
 <p class="text-danger" v-if="$v.value.required === false && $v.value.$dirty">Field is required.</p>


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5788

## Description
Changes input type to email.

## Screenshots/screencasts
![photo_2020-03-20_10-53-49](https://user-images.githubusercontent.com/52824207/77148876-17334d00-6a99-11ea-8beb-bd286c310b57.jpg)

## Backward compatibility
This change is fully backward compatible.