### PR TITLE
Allow a user to reset form to its default values

### DIFF
--- a/js/components/buttons.js
+++ b/js/components/buttons.js
@@ -30,7 +30,7 @@ Fliplet.FormBuilder.field('buttons', {
     },
     clearType: {
       type: String,
-      default: 'reset'
+      default: 'button'
     },
     type: {
       type: String,


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6087

## Description
Allow a user to reset form to its default values

## Screenshots/screencasts
https://share.getcloudapp.com/v1urnkv8

## Backward compatibility

This change is fully backward compatible.

## Notes
Please merge this [PR](https://github.com/Fliplet/fliplet-widget-form-builder/pull/290) before approving this.