### PR TITLE
Checkbox and rich text values will be restored on clear button press

### DIFF
--- a/js/components/checkbox.js
+++ b/js/components/checkbox.js
@@ -6,10 +6,6 @@ Fliplet.FormBuilder.field('checkbox', {
       type: Array,
       default: []
     },
-    defaultValue: {
-      type: String,
-      default: ''
-    },
     options: {
       type: Array,
       default: [
@@ -61,12 +57,11 @@ Fliplet.FormBuilder.field('checkbox', {
     }
   },
   created: function () {
-    if (!!this.defaultValue) {
-      this.value = this.defaultValue.split(/\n/);
-      this.updateValue(this.name, this.value);
-    } else if (!Array.isArray(this.value)) {
-      this.value = [];
-      this.updateValue(this.name, this.value);
+    // We have removed defaultValue variable and set value intead
+    // Because default value wasn't saving in the global data variable ib that case and we couldn't restore default value
+    if (!Array.isArray(this.value)) {
+      this.value = this.value.split(/\n/);
+      this.updateValue();
     }
   }
 });

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -42,11 +42,9 @@ Fliplet.FormBuilder.field('wysiwyg', {
     onReset: function () {
       if (this.editor) {
         try {
-          return this.editor.setContent('');
+          return this.editor.setContent(this.value);
         } catch (e) {}
       }
-
-      this.value = '';
     },
     placeholderLabel: function () {
       var placeholderText = this.editor.getElement().getAttribute("placeholder") || this.editor.settings.placeholder;

--- a/js/interface.templates.js
+++ b/js/interface.templates.js
@@ -7,7 +7,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.configurations.buttons"] = Han
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.configurations.checkbox"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<div class=\"form-group\">\n  <label>Default values <small>(One per line)</small></label>\n  <textarea class=\"form-control\" v-model.trim=\"defaultValue\" placeholder=\"Default values\" />\n</div>\n";
+    return "<div class=\"form-group\">\n  <label>Default values <small>(One per line)</small></label>\n  <textarea class=\"form-control\" v-model.trim=\"value\" placeholder=\"Default values\" />\n</div>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.configurations.date"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -263,6 +263,12 @@ Fliplet.Widget.instance('form-builder', function(data) {
         this.fields.forEach(function(field, index) {
           var value = data.fields[index].value;
 
+          // CheckBox default value is saving as a text with /\n/ as a saparator
+          // But for correct work it need to be an array
+          if (field._type === 'flCheckbox' && !Array.isArray(value)) {
+            value = value.split(/\n/);
+          }
+
           // Clone value if it's an array to ensure the original object does not mutate
           if (Array.isArray(value)) {
             value = value.slice(0);

--- a/templates/configurations/checkbox.interface.hbs
+++ b/templates/configurations/checkbox.interface.hbs
@@ -1,4 +1,4 @@
 <div class="form-group">
   <label>Default values <small>(One per line)</small></label>
-  <textarea class="form-control" v-model.trim="defaultValue" placeholder="Default values" />
+  <textarea class="form-control" v-model.trim="value" placeholder="Default values" />
 </div>


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6087

## Description
Checkbox and rich text values will be restored on clear button press

## Screenshots/screencasts
https://share.getcloudapp.com/OAurZAyk

## Backward compatibility

This change is fully backward compatible.