### PR TITLE
Checkbox and rich text values will be restored on clear button press

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -42,11 +42,9 @@ Fliplet.FormBuilder.field('wysiwyg', {
     onReset: function () {
       if (this.editor) {
         try {
-          return this.editor.setContent('');
+          return this.editor.setContent(this.value);
         } catch (e) {}
       }
-
-      this.value = '';
     },
     placeholderLabel: function () {
       var placeholderText = this.editor.getElement().getAttribute("placeholder") || this.editor.settings.placeholder;

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -261,8 +261,17 @@ Fliplet.Widget.instance('form-builder', function(data) {
         var $vm = this;
 
         this.fields.forEach(function(field, index) {
-          var value = data.fields[index].value;
+          var value;
 
+          if (field._type === 'flCheckbox') {
+            value = data.fields[index].defaultValue || data.fields[index].value;
+            if (!Array.isArray(value)) {
+              value = value.split(/\n/);
+            }
+          } else {
+            value = data.fields[index].value;
+          }
+          
           // Clone value if it's an array to ensure the original object does not mutate
           if (Array.isArray(value)) {
             value = value.slice(0);


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6087

## Description
Checkbox and rich text values will be restored on clear button press

## Screenshots/screencasts
https://share.getcloudapp.com/7KuR9nkg

## Backward compatibility

This change is fully backward compatible.

## Notes
Remade old [PR ](https://github.com/Fliplet/fliplet-widget-form-builder/pull/293)so it doesn't need to update handelbars templates.