### PR TITLE
Removed from the error text that 'SPACE' is allowed to not confuse users.

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -71,7 +71,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.starRating"] = Hand
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.telephone"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<input\n  type=\"tel\"\n  class=\"form-control\"\n  v-model.trim.lazy=\"value\"\n  v-on:blur=\"updateValue()\"\n  v-on:input=\"onInput($event)\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n/>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">Field is required.</p>\n<p class=\"text-danger\" v-if=\"$v.value.phone === false && $v.value.$dirty\">Phone could contain <b>; , . ( ) - + SPACE * #</b> and numbers.</p>\n";
+    return "<input\n  type=\"tel\"\n  class=\"form-control\"\n  v-model.trim.lazy=\"value\"\n  v-on:blur=\"updateValue()\"\n  v-on:input=\"onInput($event)\"\n  :name=\"name\"\n  :id=\"name\"\n  :placeholder=\"placeholder\"\n/>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">Field is required.</p>\n<p class=\"text-danger\" v-if=\"$v.value.phone === false && $v.value.$dirty\">Phone could contain <b>; , . ( ) - + * #</b> and numbers.</p>\n";
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.textarea"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {

--- a/templates/components/telephone.build.hbs
+++ b/templates/components/telephone.build.hbs
@@ -9,4 +9,4 @@
   :placeholder="placeholder"
 />
 <p class="text-danger" v-if="$v.value.required === false && $v.value.$dirty">Field is required.</p>
-<p class="text-danger" v-if="$v.value.phone === false && $v.value.$dirty">Phone could contain <b>; , . ( ) - + SPACE * #</b> and numbers.</p>
+<p class="text-danger" v-if="$v.value.phone === false && $v.value.$dirty">Phone could contain <b>; , . ( ) - + * #</b> and numbers.</p>


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5343

## Description
Removed from the error text that 'SPACE' is allowed to not confuse users.

## Screenshots/screencasts
![phone correct error](https://user-images.githubusercontent.com/53430352/79114210-5d738780-7d8b-11ea-9ed0-df841d08cb84.png)


## Backward compatibility

This change is fully backward compatible.