### PR TITLE
fixes checkbox not populating existing values

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -164,7 +164,7 @@ Fliplet.Widget.instance('form-builder', function(data) {
 
                 fieldData.forEach(function (element) {
                   var match = _.find(field.options, function (option) {
-                    return option.label === fieldData || option.id === fieldData
+                    return option.label === element || option.id === element;
                   });
 
                   if (match) {


### PR DESCRIPTION
ref https://github.com/Fliplet/fliplet-studio/issues/6256

It looks like the code was broken by a commit made by Upplabs back in December 2019: https://github.com/Fliplet/fliplet-widget-form-builder/commit/b258624ef76ecc395f27ec02d5f07507337c32b1#diff-aab0ddc8ded3b82294a8d0537f15e112L162