### PR TITLE
Allow using spaces in the telephone field

### DIFF
--- a/js/components/telephone.js
+++ b/js/components/telephone.js
@@ -9,7 +9,7 @@ Fliplet.FormBuilder.field('telephone', {
   validations: function () {
     var rules = {
       value: {
-        phone: window.validators.helpers.regex('', /^[0-9;,.()\-+\n*#]+$/)
+        phone: window.validators.helpers.regex('', /^[0-9;,.()\-+\s*#]+$/)
       }
     };
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5343

## Description
Allow using spaces in the telephone field

## Screenshots/screencasts
https://share.getcloudapp.com/2NuXrB64

## Backward compatibility

This change is fully backward compatible.