### PR TITLE
Users can use shortcuts in the Rich text to add an unordered list

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -103,6 +103,19 @@ Fliplet.FormBuilder.field('wysiwyg', {
       this.editor.on('change', this.onPlaceholderBlur);
       this.editor.on('setContent', this.onPlaceholderBlur);
       this.editor.on('keydown', this.hidePlaceholderLabel);
+    },
+    addBulletedListShortcuts: function () {
+      var $vm = this;
+
+      // For Windows
+      this.editor.addShortcut('ctrl+shift+8', 'UnorderedList', function() {
+        $vm.editor.execCommand('InsertUnorderedList');
+      });
+
+      // For MacOS
+      this.editor.addShortcut('command+[', 'UnorderedList', function() {
+        $vm.editor.execCommand('InsertUnorderedList');
+      });
     }
   },
   mounted: function () {
@@ -141,6 +154,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
 
         editor.on('init', function () {
           $vm.addPlaceholder();
+          $vm.addBulletedListShortcuts();
 
           // initialise value if it was set prior to initialisation
           if ($vm.value) {


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6085

## Description
Added two new shortcuts for the unordered list to call.
Use `ctrl+shift+8` for Windows and `command+[` for macOS to call bulleted list in the Rich text.

## Screenshots/screencasts
https://share.getcloudapp.com/eDu69wnX

## Backward compatibility

This change is fully backward compatible.

## Notes
Using this [command](https://www.tiny.cloud/docs-4x/api/tinymce/tinymce.editor/#addshortcut) to add a new shortcut for the TinyMCE.

## Reviewers 
@upplabs-alex-levchenko @MaksymShokin 