### PR TITLE
Updated regex to allow % sign in the URL

### DIFF
--- a/js/components/url.js
+++ b/js/components/url.js
@@ -9,8 +9,8 @@ Fliplet.FormBuilder.field('url', {
   validations: function () {
     var rules = {
       value: {
-        // URL regex taken form https://www.regextester.com/94502
-        url: window.validators.helpers.regex('', /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\*\+,;=.]+$/i)
+        // URL regex taken form https://www.regextester.com/94502 and added % sign
+        url: window.validators.helpers.regex('', /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@%!\$&'\*\+,;=.]+$/i)
       }
     };
 


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6328

## Description
Updated regex to allow % sign in the URL

## Screenshots/screencasts
![url-update](https://user-images.githubusercontent.com/52824207/81468718-f4e0c480-91e9-11ea-9e0e-c0f8244ec64b.gif)

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko