### PR TITLE
[Fix] Config save will be saved after clicking Done button

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -219,6 +219,9 @@ var app = new Vue({
       Object.keys(fieldData).forEach(function(prop) {
         $vm.activeField[prop] = fieldData[prop];
       });
+
+      $vm.save();
+      Fliplet.Studio.emit('reload-widget-instance', widgetId);
       this.closeEdit();
     },
     changeTemplate: function() {


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6534

## Description
Configuration field will be saved after clicking the Done button.

## Screencast
https://streamable.com/pnyaq5

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko