### PR TITLE
[Feat] allow field.toggle not to change a field value

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -864,10 +864,15 @@ Fliplet.Widget.instance('form-builder', function(data) {
               change: function (fn, runOnBind) {
                 return $form.onChange(field.name, fn, runOnBind);
               },
-              toggle: function (isEnabled) {
+              /**
+               * Toggles a field visibility
+               * @param {Boolean} isEnabled - toggles the field visibility on and off
+               * @param {Boolean} revertValueToDefault - defaults to true - Whether the value should be reverted to its original value when showing the field
+               */
+              toggle: function (isEnabled, revertValueToDefault) {
                 field.enabled = !!isEnabled;
 
-                if (!field.enabled) {
+                if (!field.enabled && revertValueToDefault !== false) {
                   JSON.parse(JSON.stringify(data.fields || [])).some(function (f) {
                     if (field.name === f.name) {
                       field.value = f.value;


### PR DESCRIPTION
`field.toggle` currently resets the field value to the initial value when the field is set to be shown. I have therefore added an optional parameter not to change its value when the field is presented back.

ref https://github.com/Fliplet/fliplet-studio/issues/6919