### PR TITLE
[Fix] Added correct selection for Rich text

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -81,7 +81,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
       tinymce.DOM.setStyle(this.labelElement, 'display', '');
     },
     onPlaceholderFocus: function () {
-      var outlineContainer = document.querySelector('.mce-container-body.mce-stack-layout');
+      var outlineContainer = this.$el.querySelector('.mce-container-body.mce-stack-layout');
 
       if (outlineContainer) {
         outlineContainer.classList.add('focus-outline-active');
@@ -95,7 +95,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
       this.editor.execCommand('mceFocus', false);
     },
     onPlaceholderBlur: function () {
-      var outlineContainer = document.querySelector('.mce-container-body.mce-stack-layout');
+      var outlineContainer = this.$el.querySelector('.mce-container-body.mce-stack-layout');
 
       if (outlineContainer) {
         outlineContainer.classList.remove('focus-outline-active');


### PR DESCRIPTION
@sofiiakvasnevska

## Issue
https://github.com/Fliplet/fliplet-studio/issues/6422

## Description
The container will be selected from the current Rich text component.

## Screencast
https://streamable.com/fmycyc

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko