### PR TITLE
ID-328 [Feat] Support for sending image names via base64

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -200,11 +200,12 @@ Fliplet.FormBuilder.field('image', {
 
           var scaledImage = loadImage.scale(img, options);
           var imgBase64Url = scaledImage.toDataURL(mimeType, $vm.jpegQuality);
+          var flipletBase64Url = imgBase64Url + ';filename:' + file.name;
 
-          $vm.value.push(imgBase64Url);
+          $vm.value.push(flipletBase64Url);
 
           if (addThumbnail) {
-            addThumbnailToCanvas(imgBase64Url, $vm.value.length - 1, $vm);
+            addThumbnailToCanvas(flipletBase64Url, $vm.value.length - 1, $vm);
           }
 
           $vm.$emit('_input', $vm.name, $vm.value);

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -38,7 +38,7 @@ function addThumbnailToCanvas(imageURI, indexCanvas, self, isFileCanvas) {
 
   if (!imageURI.match(/^http/)) {
     imageURI = (imageURI.indexOf('base64') > -1)
-      ? imageURI
+      ? imageURI.split(';filename:')[0]
       :'data:image/jpeg;base64,' + imageURI;
   }
 


### PR DESCRIPTION
requires https://github.com/Fliplet/fliplet-api/pull/4332 to be deployed before this is released.