### PR TITLE
ID-370 [Chore] Only load templates when form isn't configured

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -769,6 +769,19 @@ var app = new Vue({
         })
       });
       return $html.html();
+    },
+    loadTemplates: function() {
+      if (data.fields) {
+        return Promise.resolve(); // do not load templates when editing a form as such UI is not shown
+      }
+
+      var $vm = this;
+
+      return Fliplet.FormBuilder.templates().then(function(templates) {
+        $vm.templates = templates.system.concat(templates.organization);
+        $vm.systemTemplates = templates.system;
+        $vm.organizationTemplates = templates.organization;
+      });
     }
   },
   watch: {
@@ -906,11 +919,7 @@ var app = new Vue({
 
     Fliplet.FormBuilder.on('field-settings-changed', this.onFieldSettingChanged);
 
-    Fliplet.FormBuilder.templates().then(function(templates) {
-      $vm.templates = templates.system.concat(templates.organization);
-      $vm.systemTemplates = templates.system;
-      $vm.organizationTemplates = templates.organization;
-
+    this.loadTemplates().then(function () {
       $(selector).removeClass('is-loading');
 
       $($vm.$refs.templateDescription).tinymce({


### PR DESCRIPTION
The form templates loading request will now run only when the form isn't configured and the "choose template" UI is shown to the user.