### PR TITLE
ID-469 [Fix] Authenticate images only for displaying thumbnail

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -40,6 +40,8 @@ function addThumbnailToCanvas(imageURI, indexCanvas, self, isFileCanvas) {
     imageURI = (imageURI.indexOf('base64') > -1)
       ? imageURI.split(';filename:')[0]
       :'data:image/jpeg;base64,' + imageURI;
+  } else {
+    imageURI = Fliplet.Media.authenticate(imageURI);
   }
 
   $vm.$nextTick(function () {
@@ -197,9 +199,6 @@ Fliplet.Widget.instance('form-builder', function(data) {
                 field.value.push(img);
               }
 
-              field.value = field.value.map(function (url) {
-                return Fliplet.Media.authenticate(url);
-              });
               break;
 
             case 'flTime':


### PR DESCRIPTION
Avoids saving back URLs that have already been authenticated, which creates security issues among not being accessible anymore when the user logs out.