### PR TITLE
OD-244 [Fix] Autofill time picker value with the current time when it is empty

### DIFF
--- a/js/components/time.js
+++ b/js/components/time.js
@@ -78,5 +78,14 @@ Fliplet.FormBuilder.field('time', {
     }
 
     $vm.$v.$reset();
+  },
+  watch: {
+    value: function(val) {
+      if (!val) {
+        this.$emit('_input', this.name, moment(new Date()).format('HH:mm'));
+      } else {
+        this.$emit('_input', this.name, val);
+      }
+    }
   }
 });

--- a/js/components/time.js
+++ b/js/components/time.js
@@ -82,7 +82,7 @@ Fliplet.FormBuilder.field('time', {
   watch: {
     value: function(val) {
       if (!val) {
-        this.updateValue(moment(new Date()).format('HH:mm'));
+        this.updateValue(moment().format('HH:mm'));
       }
     }
   }

--- a/js/components/time.js
+++ b/js/components/time.js
@@ -82,9 +82,7 @@ Fliplet.FormBuilder.field('time', {
   watch: {
     value: function(val) {
       if (!val) {
-        this.$emit('_input', this.name, moment(new Date()).format('HH:mm'));
-      } else {
-        this.$emit('_input', this.name, val);
+        this.updateValue(moment(new Date()).format('HH:mm'));
       }
     }
   }


### PR DESCRIPTION
@sofiiakvasnevska
## Issue
OD-244 https://weboo.atlassian.net/browse/OD-244
## Description
Autofill time picker value with the current time when it is empty
## Screenshots/screencasts
https://monosnap.com/file/msxievJf5RHLHNhjUzZmYSe4PkpYXw
## Backward compatibility
This change is fully backward compatible.
## Reviewers 
@upplabs-alex-levchenko @YaroslavOvdii 