### PR TITLE
ID-817 [Fix] Prevent URLs in TinyMCE from converted to relative paths

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -155,6 +155,11 @@ Fliplet.FormBuilder.field('wysiwyg', {
       image_advtab: true,
       menubar: false,
       statusbar: false,
+      // Prevent URLs from being altered
+      // https://stackoverflow.com/questions/3796942
+      relative_urls: false,
+      remove_script_host: false,
+      convert_urls: true,
       inline: false,
       resize: false,
       autoresize_bottom_margin: 0,


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-817

URLs entered via the WYSIWYG source code editor was being converted from absolute URLs:

![image](https://user-images.githubusercontent.com/290733/110785943-6f8fcb80-8263-11eb-916a-a622d5bd9e38.png)

...to relative paths:

![image](https://user-images.githubusercontent.com/290733/110785971-79b1ca00-8263-11eb-84e6-ca8907a5da2b.png)

The image works for web apps but doesn't work for native apps. The [newly added configuration](https://stackoverflow.com/questions/3796942) prevents the absolute URLs from being converted to relative paths.