### PR TITLE
OD-605 [FIX] Hint when hiding option to Add new submissions

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -147,6 +147,18 @@
             </div>
 
             <h3>Submission</h3>
+            <div  v-if="!settings.dataStore.length" class="form-group">
+              <div class="control-label">
+                <label>When the form is loaded...</label>
+              </div>
+              <div class="checkbox checkbox-icon">
+                <input type="checkbox" id="autobindProfileEditing" v-model="settings.autobindProfileEditing" :value="true">
+                <label for="autobindProfileEditing">
+                  <span class="check"><i class="fa fa-check"></i></span> Load the data from user's profile
+                  <p class="help-block"><small>If the user is signed in to the app, they will be able to edit their user profile using this form.</small></p>
+                </label>
+              </div>
+            </div>
             <div class="form-group" v-if="showDataSourceSettings">
               <div class="control-label">
                 <label>When the form is submitted...</label>
@@ -229,18 +241,6 @@
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div  v-if="!settings.dataStore.length" class="form-group">
-              <div class="control-label">
-                <label>When the form is loaded...</label>
-              </div>
-              <div class="checkbox checkbox-icon">
-                <input type="checkbox" id="autobindProfileEditing" v-model="settings.autobindProfileEditing" :value="true">
-                <label for="autobindProfileEditing">
-                  <span class="check"><i class="fa fa-check"></i></span> Load the data from user's profile
-                  <p class="help-block"><small>If the user is signed in to the app, they will be able to edit their user profile using this form.</small></p>
-                </label>
               </div>
             </div>
             <div class="form-group">

--- a/interface.html
+++ b/interface.html
@@ -158,6 +158,11 @@
                     <span class="check"><i class="fa fa-check"></i></span> Add new submissions to a data source
                   </label>
                 </div>
+                <div v-if="settings.autobindProfileEditing">
+                  <p class="help-block">
+                    <small>If the form loads data from user’s profile, it can only be used to ypdate the user’s profile.</small>
+                  </p>
+                </div>
 
                 <div class="hidden-settings" v-bind:class="{ 'active': showExtraAdd, 'hidden': !showExtraAdd }">
                   <div class="form-group">


### PR DESCRIPTION
@sofiiakvasnevska @inna-bieshulia

OD-605 https://weboo.atlassian.net/browse/OD-605

Description
**Problem:** In the form settings, if a user has selected the option to load data from a user's profile, the option to Add new submissions to a data source is hidden.
**Solution:** Added a help block for hints when the option to Add new submissions to a data source is hidden.

Screenshots/screencasts
https://storyxpress.co/video/kt9xvt3pw7wqy6naf

Backward compatibility
This change is fully backward compatible.

Reviewers
@upplabs-alex-levchenko