### PR TITLE
OD-629 [Fix] Ensures hidden fields in forms are not displayed to users

### DIFF
--- a/js/libs/core.js
+++ b/js/libs/core.js
@@ -201,11 +201,11 @@ Fliplet.FormBuilder = (function() {
       };
 
       component.computed._showField = function() {
-        if (this.readonly) {
-          if (this.isHidden) {
-            return false;
-          }
+        if (this.isHidden) {
+          return false;
+        }
 
+        if (this.readonly) {
           if (['flTime', 'flDate'].includes(this._componentName)) {
             return true;
           }
@@ -215,10 +215,6 @@ Fliplet.FormBuilder = (function() {
           }
 
           return !!this.value;
-        }
-
-        if (this.isHidden) {
-          return false;
         }
 
         return true;


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-629 https://weboo.atlassian.net/browse/OD-629

Description
**Problem:** Hidden fields in the form are displayed to the user if the default value is added and the "read-only" option is selected, because the condition under which the field should be hidden is placed in the wrong place.
**Solution:** The condition under which the field should be hidden is moved to the beginning of the function.

Screenshots/screencasts
https://storyxpress.co/video/kui7ltnjfprp53but

Backward compatibility
This change is fully backward compatible.

Reviewers
@upplabs-alex-levchenko