### PR TITLE
OD-669 [Fix] Ensure data source hooks are kept up to date when saving forms

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -327,7 +327,9 @@ new Vue({
       // Cleanup
       this.settings.fields = _.compact(this.fields);
 
-      return Fliplet.Widget.save(this.settings);
+      return Fliplet.Widget.save(this.settings).then(function onSettingsUpdated() {
+        return $vm.updateDataSourceHooks();
+      });
     },
     createDefaultBodyTemplate: function(fields) {
       // Creates default email template
@@ -541,7 +543,7 @@ new Vue({
         return dataSource.columns || [];
       });
     },
-    updateDataSource: function() {
+    updateDataSourceHooks: function() {
       var dataSourceId = this.settings.dataSourceId;
       var newColumns = _.chain(this.fields)
         .filter(function(field) {
@@ -564,17 +566,18 @@ new Vue({
         var hooksDeleted;
         var columns = _.uniq(newColumns.concat(ds.columns));
 
-        // remove existing hooks for the operations
+        // remove existing hooks for the operations from the same widget instance
         ds.hooks = _.reject(ds.hooks || [], function(hook) {
-          var result = hook.widgetInstanceId == widgetId && hook.type == 'operations';
+          var remove = hook.widgetInstanceId == widgetId && hook.type == 'operations';
 
-          if (result) {
+          if (remove) {
             hooksDeleted = true;
           }
 
-          return result;
+          return remove;
         });
 
+        // add fields that need to be hashed to data source hooks
         if (fieldsToHash) {
           var payload = {};
 
@@ -590,7 +593,7 @@ new Vue({
           });
         } else if (!hooksDeleted) {
           if (_.isEqual(columns.sort(), ds.columns.sort())) {
-            return Promise.resolve(); // no need to update
+            return; // no need to update
           }
         }
 

--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -327,9 +327,7 @@ new Vue({
       // Cleanup
       this.settings.fields = _.compact(this.fields);
 
-      return Fliplet.Widget.save(this.settings).then(function onSettingsUpdated() {
-        return $vm.updateDataSourceHooks();
-      });
+      return Fliplet.Widget.save(this.settings);
     },
     createDefaultBodyTemplate: function(fields) {
       // Creates default email template
@@ -543,7 +541,7 @@ new Vue({
         return dataSource.columns || [];
       });
     },
-    updateDataSourceHooks: function() {
+    updateDataSource: function() {
       var dataSourceId = this.settings.dataSourceId;
       var newColumns = _.chain(this.fields)
         .filter(function(field) {
@@ -566,18 +564,17 @@ new Vue({
         var hooksDeleted;
         var columns = _.uniq(newColumns.concat(ds.columns));
 
-        // remove existing hooks for the operations from the same widget instance
+        // remove existing hooks for the operations
         ds.hooks = _.reject(ds.hooks || [], function(hook) {
-          var remove = hook.widgetInstanceId == widgetId && hook.type == 'operations';
+          var result = hook.widgetInstanceId == widgetId && hook.type == 'operations';
 
-          if (remove) {
+          if (result) {
             hooksDeleted = true;
           }
 
-          return remove;
+          return result;
         });
 
-        // add fields that need to be hashed to data source hooks
         if (fieldsToHash) {
           var payload = {};
 
@@ -593,7 +590,7 @@ new Vue({
           });
         } else if (!hooksDeleted) {
           if (_.isEqual(columns.sort(), ds.columns.sort())) {
-            return; // no need to update
+            return Promise.resolve(); // no need to update
           }
         }
 


### PR DESCRIPTION
@romanyosyfiv

OD-669 https://weboo.atlassian.net/browse/OD-669

Follows https://github.com/Fliplet/fliplet-widget-form-builder/pull/424

## Description
**Problem**: The [PR](https://github.com/Fliplet/fliplet-widget-form-builder/pull/419) code was mistakenly reverted by [this commit](https://github.com/Fliplet/fliplet-widget-form-builder/pull/424/commits/e1e11ef88f329d8160a6c31f69597b4787195303) from [this PR](https://github.com/Fliplet/fliplet-widget-form-builder/pull/424)
**Solution**: [PR](https://github.com/Fliplet/fliplet-widget-form-builder/pull/419) code has been restored

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko