### PR TITLE
OD-643 [Fix]  Adjusted document and image add-button padding

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -977,6 +977,10 @@ form hr {
     width: 100%;
     height: 130px;
   }
+
+  label.btn.btn-primary {
+    padding-right: 25px;
+  }
 }
 
 .form-group .mce-btn-group {

--- a/css/form.css
+++ b/css/form.css
@@ -978,8 +978,8 @@ form hr {
     height: 130px;
   }
 
-  label.btn.btn-primary {
-    padding-right: 25px;
+  label.btn.btn-primary > span {
+    margin-right: 25px;
   }
 }
 


### PR DESCRIPTION
@romanyosyfiv @inna-bieshulia

OD-643 https://weboo.atlassian.net/browse/OD-643

## Description
**Problem:** There is a padding for the button, which is not designed to have a picture inside.
**Solution:** Added a new padding on the right that lengthens the button.

## Screenshots/screencasts
https://storyxpress.co/video/kwdn3tklg6o5s7ppd

## Backward compatibility
This change is fully backward compatible.

## Reviewers
@upplabs-alex-levchenko