### PR TITLE
ID-2397 [Fix] Form getters

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -62,6 +62,8 @@ function addThumbnailToCanvas(imageURI, indexCanvas, self, isFileCanvas) {
   });
 }
 
+
+
 // Wait for form fields to be ready, as they get defined after translations are initialized
 Fliplet().then(function () {
   Fliplet.Widget.instance('form-builder', function(data) {
@@ -1070,33 +1072,37 @@ Fliplet().then(function () {
 });
 
 Fliplet.FormBuilder.get = function (name) {
-  return Promise.all(formBuilderInstances).then(function (forms) {
-    var form;
+  return Fliplet().then(function () {
+    return Promise.all(formBuilderInstances).then(function (forms) {
+      var form;
 
-    if (typeof name === 'undefined') {
-      form = forms.length ? forms[0] : undefined;
-    } else {
-      forms.some(function (vueForm) {
-        if (vueForm.name === name) {
-          form = vueForm;
+      if (typeof name === 'undefined') {
+        form = forms.length ? forms[0] : undefined;
+      } else {
+        forms.some(function (vueForm) {
+          if (vueForm.name === name) {
+            form = vueForm;
 
-          return true;
-        }
-      });
-    }
+            return true;
+          }
+        });
+      }
 
-    return form;
+      return form;
+    });
   });
 };
 
 Fliplet.FormBuilder.getAll = function (name) {
-  return Promise.all(formBuilderInstances).then(function(forms) {
-    if (typeof name === 'undefined') {
-      return forms;
-    }
+  return Fliplet().then(function () {
+    return Promise.all(formBuilderInstances).then(function(forms) {
+      if (typeof name === 'undefined') {
+        return forms;
+      }
 
-    return forms.filter(function(form) {
-      return form.name === name;
+      return forms.filter(function(form) {
+        return form.name === name;
+      });
     });
   });
 };


### PR DESCRIPTION
For some reason it appears that calling `Fliplet.FormBuilder.get()` in custom code gets fired before forms are registered.

I am running some tests to debug the full event loop, but this patch addresses the situation.

Local tests:

![image](https://user-images.githubusercontent.com/574210/177129082-d2cd45dc-044e-43dd-9d3e-52f05e085a3a.png)
![image](https://user-images.githubusercontent.com/574210/177129380-3feab074-29e8-47ea-b942-365cbc978f3d.png)
