### PR TITLE
XOR-327 [Fix] Ensure title and paragraph fields appear with the text in form builder

### DIFF
--- a/js/components/paragraph.js
+++ b/js/components/paragraph.js
@@ -10,9 +10,7 @@ Fliplet.FormBuilder.field('paragraph', {
     },
     value: {
       type: String,
-      default: function() {
-        return T('widgets.form.paragraph.defaultValue');
-      }
+      default: 'Paragraph'
     },
     canHide: {
       type: Boolean,

--- a/js/components/title.js
+++ b/js/components/title.js
@@ -10,9 +10,7 @@ Fliplet.FormBuilder.field('title', {
     },
     value: {
       type: String,
-      default: function() {
-        return T('widgets.form.title.defaultValue');
-      }
+      default: 'Title'
     },
     canHide: {
       type: Boolean,


### PR DESCRIPTION
**Product areas affected**

Form -> Edit form -> Add fields -> Formatting -> Title
Form -> Edit form -> Add fields -> Formatting -> Paragraph

**What does this PR do?**

currently showing the code instated of showing the title and paragraph text. We fixed the title and paragraph fields appear with the text as “Title” and “Paragraph” respectively.

**JIRA ticket**

[click here](https://weboo.atlassian.net/browse/XOR-327)

**Result**

https://user-images.githubusercontent.com/102005879/181467843-47fab1d5-59d8-4a4e-b689-bcfe06e90576.mp4

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None