### PR TITLE
XOR-289 [Feat] Ensure in edit form field only one set of Save/Cancel button showing

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -107,6 +107,8 @@ var SAVE_BUTTON_LABELS = {
   SAVE_AND_CLOSE: 'Save & Close'
 };
 
+var CANCEL_BUTTON_LABEL = 'Cancel';
+
 // Wait for form fields to be ready, as they get defined after translations are initialized
 Fliplet().then(function() {
   new Vue({
@@ -261,12 +263,16 @@ Fliplet().then(function() {
         this.activeField = field;
         changeSelectText();
         Fliplet.Studio.emit('widget-save-label-update');
+        Fliplet.Studio.emit('widget-cancel-label-update');
+        Fliplet.Widget.toggleCancelButton(false);
         this.$forceUpdate();
       },
       closeEdit: function() {
         this.activeFieldConfigType = null;
         this.activeField = {};
         Fliplet.Studio.emit('widget-save-label-reset');
+        Fliplet.Widget.setCancelButtonLabel(CANCEL_BUTTON_LABEL);
+        Fliplet.Widget.toggleCancelButton(true);
       },
       onFieldSettingChanged: function(fieldData) {
         var $vm = this;
@@ -277,6 +283,8 @@ Fliplet().then(function() {
 
         $vm.save();
         Fliplet.Studio.emit('reload-widget-instance', widgetId);
+        Fliplet.Widget.setCancelButtonLabel(CANCEL_BUTTON_LABEL);
+        Fliplet.Widget.toggleCancelButton(true);
         this.closeEdit();
       },
       changeTemplate: function() {

--- a/templates/configurations/form.interface.hbs
+++ b/templates/configurations/form.interface.hbs
@@ -124,6 +124,6 @@
   </div>
 
   <div class="footer">
-    <button type="submit" class="btn btn-primary" :class="{ disabled: _fieldNameError || _fieldLabelError }">Done</button>
+    <button type="submit" class="btn btn-primary" :class="{ disabled: _fieldNameError || _fieldLabelError }">Save</button>
   </div>
 </form>


### PR DESCRIPTION
### Product areas affected

Widget -> Form -> Edit Form Field -> Save / Cancel 

### What does this PR do?

Implemented logic while editing form field only one set of Save and Cancel button will show.

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-289)

### Result

![image](https://user-images.githubusercontent.com/108272606/183595212-d8401c31-d698-4ecd-8ac5-55b476231f65.png)

### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none