### PR TITLE
XOR-415 [Fix] Ensuring the Title field allows user to add another field named Title

### DIFF
--- a/js/components/paragraph.js
+++ b/js/components/paragraph.js
@@ -1,5 +1,5 @@
 Fliplet.FormBuilder.field('paragraph', {
-  name: 'Paragraph',
+  name: 'Format Paragraph',
   category: 'Formatting',
   submit: false,
   props: {

--- a/js/components/title.js
+++ b/js/components/title.js
@@ -1,5 +1,5 @@
 Fliplet.FormBuilder.field('title', {
-  name: 'Title',
+  name: 'Format Title',
   category: 'Formatting',
   submit: false,
   props: {


### PR DESCRIPTION
### Product areas affected

Widgets -> Form Widget  -> Add Title from Format section -> Add Input field -> Change name to Title of Input field

### What does this PR do?

Implemented fix so that Formatting Title field allows user to add other field named as Title.

### JIRA ticket

[JIRA](https://weboo.atlassian.net/browse/XOR-415)

### Result

[XOR-Test-415.webm](https://user-images.githubusercontent.com/108272606/189140099-a94fb5a5-9851-4b43-abd1-8971788e0e34.webm)


### Checklist

none

### Testing instructions

none

### Deployment instructions

none

### Author concerns

none