### PR TITLE
ID-2845 [FEAT] Add afterFormEntryLoad hook for accessing data source entry after it's loaded in a form

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1175,6 +1175,7 @@ Fliplet().then(function() {
               entry = record;
 
               $vm.fields = getFields(true);
+              Fliplet.Hooks.run('afterFormEntryLoad', { entry: entry });
               $vm.isLoading = false;
               $vm.$forceUpdate();
             }).catch(function(err) {


### PR DESCRIPTION
**Product areas affected**

Studio -> Form -> Form Fields

**What does this PR do?**

Implemented code, so entry data available on frontend after loading the form with dataSourceEntryId passed to it

**JIRA ticket**

[click here](https://weboo.atlassian.net/browse/ID-2845)

**Result**

https://github.com/Fliplet/fliplet-widget-form-builder/assets/108272606/62e5e3c9-d685-4c95-9fd6-2adee0f919e6

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None
