### PR TITLE
ID-2804 [FIX] Ensure attached images are not saved with the wrong orientation

### DIFF
--- a/js/components/file.js
+++ b/js/components/file.js
@@ -174,8 +174,7 @@ Fliplet.FormBuilder.field('file', {
           }, {
             canvas: true,
             maxWidth: $vm.customWidth,
-            maxHeight: $vm.customHeight,
-            orientation: true
+            maxHeight: $vm.customHeight
           });
       });
     },

--- a/js/components/file.js
+++ b/js/components/file.js
@@ -163,7 +163,7 @@ Fliplet.FormBuilder.field('file', {
     processImage: function(file, isAddElem) {
       var $vm = this;
 
-      loadImage.parseMetaData(file, function(data) {
+      loadImage.parseMetaData(file, function() {
         loadImage(
           file,
           function() {
@@ -175,8 +175,7 @@ Fliplet.FormBuilder.field('file', {
             canvas: true,
             maxWidth: $vm.customWidth,
             maxHeight: $vm.customHeight,
-            orientation: data.exif
-              ? data.exif.get('Orientation') : true
+            orientation: true
           });
       });
     },

--- a/js/components/file.js
+++ b/js/components/file.js
@@ -174,7 +174,8 @@ Fliplet.FormBuilder.field('file', {
           }, {
             canvas: true,
             maxWidth: $vm.customWidth,
-            maxHeight: $vm.customHeight
+            maxHeight: $vm.customHeight,
+            orientation: 0
           });
       });
     },

--- a/js/components/image.js
+++ b/js/components/image.js
@@ -213,12 +213,12 @@ Fliplet.FormBuilder.field('image', {
 
       this.validateValue();
 
-      loadImage.parseMetaData(file, function(data) {
+      loadImage.parseMetaData(file, function() {
         var options = {
           canvas: true,
           maxWidth: $vm.customWidth,
           maxHeight: $vm.customHeight,
-          orientation: data.exif ? data.exif.get('Orientation') : true
+          orientation: true
         };
 
         loadImage(file, function(img) {

--- a/js/components/image.js
+++ b/js/components/image.js
@@ -217,7 +217,8 @@ Fliplet.FormBuilder.field('image', {
         var options = {
           canvas: true,
           maxWidth: $vm.customWidth,
-          maxHeight: $vm.customHeight
+          maxHeight: $vm.customHeight,
+          orientation: 0
         };
 
         loadImage(file, function(img) {

--- a/js/components/image.js
+++ b/js/components/image.js
@@ -217,8 +217,7 @@ Fliplet.FormBuilder.field('image', {
         var options = {
           canvas: true,
           maxWidth: $vm.customWidth,
-          maxHeight: $vm.customHeight,
-          orientation: true
+          maxHeight: $vm.customHeight
         };
 
         loadImage(file, function(img) {


### PR DESCRIPTION
**Product areas affected**

Studio -> Form -> Add image / file field

**What does this PR do?**

Implemented code, so while adding image in image or file field should not rotate

**JIRA ticket**

[ID-2804](https://weboo.atlassian.net/browse/ID-2804)

**Result**

https://github.com/Fliplet/fliplet-widget-chat/assets/108272606/8088196c-f6a5-4595-9fb6-5b9f8ee2fc7d

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None

[ID-2804]: https://weboo.atlassian.net/browse/ID-2804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ