### PR TITLE
ID-3677 [FIX] Code scanner btn do not have spacing underneath

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -1182,10 +1182,6 @@ form hr {
     display: flex;
   }
 
-  .form-html .btn {
-    margin-bottom: 0;
-  }
-
   .form-html .btn + .btn {
     margin-right: 15px;
   }


### PR DESCRIPTION
#### Result

![image](https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/9f7af924-cc7d-4918-aec3-d15f73a366bf)
