### PR TITLE
ID-3849 [FIX] Ensure to close the toolbar in full screen on mobile preview

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -115,6 +115,12 @@ Fliplet.FormBuilder.field('wysiwyg', {
       setup: function(editor) {
         $vm.editor = editor;
 
+        editor.on('click', function() {
+          if (tinymce.activeEditor.queryCommandState('ToggleToolbarDrawer')) {
+            tinymce.activeEditor.execCommand('ToggleToolbarDrawer');
+          }
+        });
+
         editor.on('init', function() {
           $vm.addBulletedListShortcutsWindows();
 


### PR DESCRIPTION
### Result

https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/0f02d14c-f459-48a7-a1a9-5c591839d0fc

