### PR TITLE
ID-3977 [FIX] Move rich text '...' to the right corner on mobile and tablet

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -1095,6 +1095,12 @@ html[dir="rtl"] .radio.radio-icon input[type="radio"] + label > span.check {
   border-radius: 4px;
 }
 
+@media screen and (max-width: 1280px) {
+  .tox-toolbar__primary {
+    justify-content: space-between;
+  }
+}
+
 /* DATE AND TIME PICKER */
 
 .form-group.fl-time-picker.readonly > .fa:first-child,


### PR DESCRIPTION
### Result 
![image](https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/9406be37-fa36-4376-8bcc-48e0f84dbf61)
![image](https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/f63da66f-4cbe-445a-a5df-7c0790e5d52a)
![image](https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/51c6029e-57b1-4f89-befb-11729f87eb48)
