### PR TITLE
ID-3993 [FIX] Ensure typeahead not triggers infinite loop

### DIFF
--- a/js/components/typeahead.js
+++ b/js/components/typeahead.js
@@ -118,6 +118,10 @@ Fliplet.FormBuilder.field('typeahead', {
   },
   watch: {
     value: function(val) {
+      if (this.maxItems && val.length > this.maxItems) {
+        val = val.slice(0, this.maxItems);
+      }
+
       if (this.typeahead) {
         this.typeahead.set(val);
       }

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -556,11 +556,7 @@ Fliplet().then(function() {
             var savedValue = progress[field.name];
 
             if (typeof savedValue !== 'undefined') {
-              if (field._type === 'flTypeahead') {
-                setTypeaheadFieldValue(field, savedValue);
-              } else {
-                field.value = savedValue;
-              }
+              field.value = savedValue;
             }
           }
 


### PR DESCRIPTION
When we are trying to assign a field value from LFD that contains more items than the field max items value, the field triggers an infinite loop.

**What does this PR do?**

Splits the field value with the max items count if it is provided.

### Result 
https://www.loom.com/share/dc7e30b48c0347579afdec4ddd78eed2?sid=9d11d0a6-355e-4bed-9377-3a50686dd9b4