### PR TITLE
ID-3998 [Fix] Allow form name to be used correctly for filtering

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1420,7 +1420,7 @@ Fliplet().then(function() {
 
           // This data is available through "Fliplet.FormBuilder.get()"
           formReady({
-            name: data.name,
+            name: data.displayName,
             // Deprecated property but kept for legacy support
             instance: $form,
             $instance: $form,


### PR DESCRIPTION
Ref. https://weboo.atlassian.net/browse/ID-3998

When the form name setting was changed from `form.name` to `form.displayName` ([commit](https://github.com/Fliplet/fliplet-widget-form-builder/commit/446c470724bb366bd04ad753fdbbc275c3df5aad#diff-4afc485ba32b2951dc94b6b24e4a9d40316ffeab9ab059691604291f2d21cf00R378)), [this line](https://github.com/Fliplet/fliplet-widget-form-builder/commit/f235213492a62d66d79fea5b68fc7e7b6812de79#diff-524255b142ab5cdf4d2376cd9ecbc907441103c5db0a458e3bb3e91ce00ac8ffR371) should have been changed to use the `displayName` key as well.