### PR TITLE
ID-4051 [FIX] Ensure to not set empty value to typeahead on form reset

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -675,10 +675,18 @@ Fliplet().then(function() {
               return;
             }
 
-            if (field._type === 'flCheckbox' || field._type === 'flTypeahead') {
+            if (field._type === 'flCheckbox') {
               value = fieldSettings.defaultValue || fieldSettings.value;
 
               if (typeof value !== 'undefined' && !Array.isArray(value)) {
+                value = value.split(/\n/);
+              }
+            } else if (field._type === 'flTypeahead') {
+              value = fieldSettings.defaultValue || fieldSettings.value;
+
+              if (value === '') {
+                value = null;
+              } else if (typeof value !== 'undefined' && !Array.isArray(value)) {
                 value = value.split(/\n/);
               }
             } else if (field._type === 'flDate') {


### PR DESCRIPTION
### Result

https://www.loom.com/share/2acf2a4ed33542f28c47f561c135fe19?sid=42a5b6bf-95d0-4818-8e0a-d4111c4ced54