### PR TITLE
ID-4052 resetting read only input

### DIFF
--- a/js/components/input.js
+++ b/js/components/input.js
@@ -43,7 +43,7 @@ Fliplet.FormBuilder.field('input', {
       }
     },
     onReset: function(data) {
-      if (this.readonly || !data || data.id !== this.$parent.id) {
+      if (!data || data.id !== this.$parent.id) {
         return;
       }
 

--- a/js/components/input.js
+++ b/js/components/input.js
@@ -43,7 +43,7 @@ Fliplet.FormBuilder.field('input', {
       }
     },
     onReset: function(data) {
-      if (!data || data.id !== this.$parent.id) {
+      if (this.readonly || !data || data.id !== this.$parent.id) {
         return;
       }
 

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -671,7 +671,7 @@ Fliplet().then(function() {
             var value;
             var fieldSettings = data.fields[index];
 
-            if (field.isHidden) {
+            if (field.isHidden || field.readonly) {
               return;
             }
 


### PR DESCRIPTION
## What does this PR do?
It prevents resetting the value of read-only **field**. This applies to all fields marked as `readonly.`

## JIRA ticket
[ID-4052](https://weboo.atlassian.net/browse/ID-4052)

[ID-4052]: https://weboo.atlassian.net/browse/ID-4052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ