### PR TITLE
ID-4037 [FIX] Reorder list issues

### DIFF
--- a/js/components/reorderList.js
+++ b/js/components/reorderList.js
@@ -17,9 +17,11 @@ Fliplet.FormBuilder.field('reorderList', {
       default: function() {
         return [
           {
+            id: 'Option 1',
             label: 'Option 1'
           },
           {
+            id: 'Option 2',
             label: 'Option 2'
           }
         ];
@@ -69,15 +71,18 @@ Fliplet.FormBuilder.field('reorderList', {
     }
   },
   watch: {
+    options: {
+      immediate: true,
+      handler(val) {
+        this.orderedOptions = _.cloneDeep(val);
+      }
+    },
     value: function(val) {
       if (val) {
         this.orderedOptions = val.map(value => this.options.find(option => option.id === value));
       }
 
       this.$emit('_input', this.name, val);
-    },
-    options: function(val) {
-      this.orderedOptions = _.cloneDeep(val);
     }
   },
   methods: {

--- a/js/libs/core.js
+++ b/js/libs/core.js
@@ -853,9 +853,11 @@ Fliplet.FormBuilder = (function() {
         this.columnOptions = null;
         this.options = [
           {
+            id: 'Option 1',
             label: 'Option 1'
           },
           {
+            id: 'Option 2',
             label: 'Option 2'
           }
         ];

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1138,6 +1138,10 @@ Fliplet().then(function() {
                   value = result;
                 }
 
+                if (type === 'flReorderList' && !value) {
+                  value = field.options ? field.options.map((option) => option.id ? option.id : option.label) : [];
+                }
+
                 if (type === 'flDateRange' || type === 'flTimeRange') {
                   if (value) {
                     appendField(`${field.name} [Start]`, value.start);


### PR DESCRIPTION
Fixes these issues: 

- Can’t drag a list item after the first time dragging and dropping it;

- Empty entries are saved to the linked DS if submitting not reordered list;

- The list has the wrong order (default) when loading it through the LFD;


[ID-4037](https://weboo.atlassian.net/browse/ID-4037)

[ID-4037]: https://weboo.atlassian.net/browse/ID-4037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ