### PR TITLE
ID-4193 [FIX] File form field issues

### DIFF
--- a/js/components/file.js
+++ b/js/components/file.js
@@ -69,8 +69,20 @@ Fliplet.FormBuilder.field('file', {
   created: function() {
     Fliplet.FormBuilder.on('reset', this.onReset);
   },
+  mounted: function() {
+    this.loadFileData();
+  },
   updated: function() {
     if (this.readonly || this.isValueUrlLink) {
+      this.loadFileData();
+    }
+  },
+  destroyed: function() {
+    Fliplet.FormBuilder.off('reset', this.onReset);
+    this.selectedFiles.length = 0;
+  },
+  methods: {
+    loadFileData: function() {
       var $vm = this;
       var isFileDataLoaded = false;
       var fileIDs = _.map(this.value, function(fileURL) {
@@ -99,13 +111,7 @@ Fliplet.FormBuilder.field('file', {
 
         $vm.value = _.sortBy(newFiles, ['name']);
       }).catch(function() {});
-    }
-  },
-  destroyed: function() {
-    Fliplet.FormBuilder.off('reset', this.onReset);
-    this.selectedFiles.length = 0;
-  },
-  methods: {
+    },
     showLocalDateFormat: function(date) {
       return TD(date, { format: 'L' });
     },


### PR DESCRIPTION
Fixes the issue when in the form settings is set “When the form is loaded...“ to “Load the data from user's profile“ and the user has saved file, the name of the file is “To be uploaded“ instead of a real file name


###Result

https://www.loom.com/share/c43d9d73af2946179c93d70d04f62429?sid=9a91c41d-0187-48cf-b395-a658d6668d9f