### PR TITLE
ID-4123 [FIX] Field height of the text area is too narrow

### DIFF
--- a/css/form.css
+++ b/css/form.css
@@ -1095,6 +1095,10 @@ html[dir="rtl"] .radio.radio-icon input[type="radio"] + label > span.check {
   border-radius: 4px;
 }
 
+.tox.tox-tinymce {
+  min-height: 130px !important;
+}
+
 @media screen and (max-width: 1280px) {
   .tox-toolbar__primary {
     justify-content: space-between;

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -73,7 +73,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
   },
   mounted: function() {
     var $vm = this;
-    var lineHeight = 40;
+    var lineHeight = 55;
 
     this.tinymceId = _.kebabCase(this.name) + '-' + $(this.$refs.textarea).parents('[data-form-builder-id]').data('formBuilderId');
 


### PR DESCRIPTION
Ensure to have proper height when row count is 1

### Result
![image](https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/d84a823e-b2bc-4f3b-a15a-ab825e2bed3c)
