### PR TITLE
ID-4239 [fix] fixed emptying date and time inputs meant to load data from ds

### DIFF
--- a/js/components/date.js
+++ b/js/components/date.js
@@ -63,7 +63,7 @@ Fliplet.FormBuilder.field('date', {
       this.empty = false;
     }
 
-    if (this.autofill === 'empty') {
+    if (this.autofill === 'empty' && this.defaultSource !== 'load') {
       this.value = '';
 
       return;

--- a/js/components/time.js
+++ b/js/components/time.js
@@ -103,7 +103,7 @@ Fliplet.FormBuilder.field('time', {
       this.empty = false;
     }
 
-    if (this.autofill === 'empty') {
+    if (this.autofill === 'empty' && this.defaultSource !== 'load') {
       this.value = '';
 
       return;


### PR DESCRIPTION
The problem was with condition race - if the field was set to `autofill: 'empty'` and was meant to load data from DS, then the first rendered field (time or date) was emptied after loading DS data. 

I've prevented emptying fields with `autofill: 'empty'` if they are about to load data from DS.

https://weboo.atlassian.net/browse/ID-4239