### PR TITLE
ID-4144 [FIX] Ensure typeahead list appears in the order we type in

### DIFF
--- a/js/components/typeahead.js
+++ b/js/components/typeahead.js
@@ -104,7 +104,8 @@ Fliplet.FormBuilder.field('typeahead', {
         options: this.options,
         freeInput: this.freeInput,
         maxItems: this.maxItems,
-        placeholder: this.placeholder
+        placeholder: this.placeholder,
+        order: this.optionsType === 'dataSource' ? 'asc' : null
       });
 
       this.typeahead.change(function(value) {


### PR DESCRIPTION
### Result

![image](https://github.com/Fliplet/fliplet-api/assets/128052346/fb02e4ba-d45b-4d82-bd4c-d1c628f6a175)
![image](https://github.com/Fliplet/fliplet-api/assets/128052346/ad747838-cf46-4414-9b7b-9535647a3375)