### PR TITLE
ID-4122 [FIX] Rich text field additional items layout overlaps for ios native

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -80,7 +80,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
     var config = {
       target: this.$refs.textarea,
       mobile: {
-        toolbar_mode: 'floating',
+        toolbar_mode: 'sliding',
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'directionality',
           'autoresize', 'fullscreen', 'code', 'paste', 'wordcount', 'table'


### PR DESCRIPTION
### Result 

https://github.com/Fliplet/fliplet-widget-form-builder/assets/128052346/e3163dd0-2383-445d-980d-d63b2374990b

