### PR TITLE
Revert "ID-4122 [FIX] Rich text field additional items layout overlaps for ios native"

### DIFF
--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -80,7 +80,7 @@ Fliplet.FormBuilder.field('wysiwyg', {
     var config = {
       target: this.$refs.textarea,
       mobile: {
-        toolbar_mode: 'sliding',
+        toolbar_mode: 'floating',
         plugins: [
           'advlist', 'autolink', 'lists', 'link', 'directionality',
           'autoresize', 'fullscreen', 'code', 'paste', 'wordcount', 'table'


### PR DESCRIPTION
Reverts Fliplet/fliplet-widget-form-builder#654 due to QA fail.