### PR TITLE
PS-29 [FIX] Ensure Typeahead field saves correctly

### DIFF
--- a/js/components/typeahead.js
+++ b/js/components/typeahead.js
@@ -133,6 +133,8 @@ Fliplet.FormBuilder.field('typeahead', {
       if (this.typeahead) {
         this.typeahead.options(val);
       }
+
+      this.typeahead.set(this.value);
     }
   }
 });

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1586,11 +1586,13 @@ Fliplet().then(function() {
                       field.value = value;
                     }
 
-                    debouncedUpdate();
 
                     if (hasChanged) {
                       $form.triggerChange(field.name, field.value);
                     }
+
+                    getFields();
+                    debouncedUpdate();
                   });
                 },
                 get: function() {


### PR DESCRIPTION
### Product areas affected

Form Builder, typeahead.js

### What does this PR do?

This PR ensures Typeahead field saves correctly.

### JIRA ticket

[PS-29](https://weboo.atlassian.net/browse/PS-29)


[PS-29]: https://weboo.atlassian.net/browse/PS-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ