### PR TITLE
DEV-201 [FIX] Ensure user is able to reset separated address parts fi…

### DIFF
--- a/js/components/address.js
+++ b/js/components/address.js
@@ -112,6 +112,10 @@ Fliplet.FormBuilder.field('address', {
     document.addEventListener('click', this.handleClickOutside);
 
     this.$emit('_input', this.name, this.value, false, true);
+
+    if (!this.manualInput) {
+      this.updateSelectedFieldsProperty('readonly', this.manualInput);
+    }
   },
   methods: {
     handleKeyDown: function(event) {

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -673,7 +673,10 @@ Fliplet().then(function() {
             var value;
             var fieldSettings = data.fields[index];
 
-            if (field.isHidden || field.readonly) {
+            const addressField = data.fields.filter(field => field._type === 'flAddress');
+            const addressSelectedFieldOptions = addressField.length ? Object.values(addressField[0].selectedFieldOptions) : [];
+
+            if (field.isHidden || (field.readonly && !addressSelectedFieldOptions.includes(field.name))) {
               return;
             }
 


### PR DESCRIPTION
### Product areas affected

Form Buider, form.js, address.js

### What does this PR do?

Ensures  user is able to reset separated address parts fields when the 'Allow users manually add or edit address' option is disabled

### JIRA ticket

[DEV-201](https://weboo.atlassian.net/browse/DEV-201)

[DEV-201]: https://weboo.atlassian.net/browse/DEV-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ