### PR TITLE
PS-53 [FIX] Ensure Rich text field is rendered in Drag and drop accor…

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -1020,15 +1020,11 @@ Fliplet().then(function() {
           Fliplet.Studio.emit('widget-mode', 'normal');
         }
       },
-      'section': function(value) {
+      'section': function() {
         var $vm = this;
 
-        if (value === 'settings') {
-          $vm.setupCodeEditor();
-          changeSelectText();
-        } else {
-          tinymce.remove();
-        }
+        $vm.setupCodeEditor();
+        changeSelectText();
       },
       'settings.dataStore': function(value) {
         this.showExtraAdd = value.indexOf('dataSource') > -1;


### PR DESCRIPTION
### Product areas affected

Form Buider, builder.js

### What does this PR do?

Ensures Rich text field is rendered in Drag and drop accordion of Add fields  overlay after switching between Component settings tabs

### JIRA ticket

[PS-53](https://weboo.atlassian.net/browse/PS-53)

[PS-53]: https://weboo.atlassian.net/browse/PS-53?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ