### PR TITLE
DEV-384 [FIX] Ensures the console error 'Cannot read properties of nu…

### DIFF
--- a/js/components/dateRange.js
+++ b/js/components/dateRange.js
@@ -136,7 +136,7 @@ Fliplet.FormBuilder.field('dateRange', {
   },
   watch: {
     value: function(val) {
-      this.selectedRange = val.selectedRange;
+      this.selectedRange = val ? val.selectedRange : null;
 
       if (!val && ['default', 'always'].indexOf(this.autofill) > -1 && (this.required || this.autofill === 'always')) {
         this.value = {


### PR DESCRIPTION
### Product areas affected

Fliiplet Form Builder

### What does this PR do?

Ensures App Advanced Analytics TypeError:  the console error 'Cannot read properties of null (reading 'selectedRange')' no longer appears on page load.

### JIRA ticket

[DEV-384](https://weboo.atlassian.net/browse/DEV-384)