### PR TITLE
PS-692 [FIX] Ensures the Image field doesn't trigger a max size error when no max size is specified.

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -232,7 +232,7 @@ Fliplet.FormBuilder.field('image', {
             return;
           }
 
-          if (img.width > $vm.customWidth || img.height > $vm.customHeight) {
+          if (($vm.customWidth && img.width > $vm.customWidth) || ($vm.customHeight && img.height > $vm.customHeight)) {
             $vm.isImageSizeExceeded = true;
 
             return;


### PR DESCRIPTION
### Product areas affected

Fliiplet Form Builder

### What does this PR do?

Ensures the Image field doesn't trigger a max size error when no max size is specified.

### JIRA ticket

[PS-692](https://weboo.atlassian.net/browse/PS-692)

[PS-692]: https://weboo.atlassian.net/browse/PS-692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ