### PR TITLE
Fix/DEV-477: Ensures previous and next slide link actions don't lead the user to the end or beginning of the slider.

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1550,7 +1550,7 @@ Fliplet().then(function() {
 
           return Promise.resolve();
         },
-        synchronizeMatchingFields: function(currentMultiStepForm, currentForm, event, arrowButton) {
+        synchronizeMatchingFields: function(currentMultiStepForm, currentForm, event) {
           Fliplet.FormBuilder.getAll().then(async function(forms) {
             try {
               const currentFormInstance = forms.find(form => form.$instance.id === currentForm.id);
@@ -1574,10 +1574,6 @@ Fliplet().then(function() {
 
                 if (!currentForm.canSwipeSlide) {
                   return;
-                }
-
-                if (arrowButton) {
-                  arrowButton.click();
                 }
               }
 
@@ -1655,11 +1651,9 @@ Fliplet().then(function() {
               button.addEventListener('click', async function(e) {
                 e.preventDefault();
 
-                const nextButton = swiperContainer.querySelector('.swiper-button-next');
-
                 const currentMultiStepForm = await getCurrentMultiStepForm(allFormsInSlide, data);
 
-                await $vm.synchronizeMatchingFields(currentMultiStepForm, data, undefined, nextButton);
+                await $vm.synchronizeMatchingFields(currentMultiStepForm, data);
               });
             });
 
@@ -1667,10 +1661,9 @@ Fliplet().then(function() {
               button.addEventListener('click', async function(e) {
                 e.preventDefault();
 
-                const prevButton = swiperContainer.querySelector('.swiper-button-prev');
                 const currentMultiStepForm = await getCurrentMultiStepForm(allFormsInSlide, data);
 
-                await $vm.synchronizeMatchingFields(currentMultiStepForm, data, undefined, prevButton);
+                await $vm.synchronizeMatchingFields(currentMultiStepForm, data);
               });
             });
           }

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1039,6 +1039,17 @@ Fliplet().then(function() {
           $(this.$el).find('input').blur();
         },
         onSubmit: function() {
+          const activeElement = document.activeElement;
+          const isPrevButton = activeElement.getAttribute('data-button-action') === 'previous-slide';
+          const isPrevArrow = activeElement.classList.contains('swiper-button-prev');
+
+          if (isPrevArrow || isPrevButton) {
+            data.canSwipeSlide = true;
+            activeElement.setAttribute('data-can-swipe', true);
+
+            return;
+          }
+
           var $vm = this;
           var formData = {};
 
@@ -1126,7 +1137,6 @@ Fliplet().then(function() {
             });
           }
 
-          const activeElement = document.activeElement;
 
           async function onFormSubmission() {
             if (!$vm.isFormValid) {

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -909,6 +909,17 @@ Fliplet().then(function() {
           Fliplet.FormBuilder.emit('reset', { id: data.id });
           this.$emit('reset');
         },
+        resetMultiStepForm: async function() {
+          const currentMultiStepForm = await getCurrentMultiStepForm(allFormsInSlide, data);
+
+          Fliplet.FormBuilder.getAll().then(function(forms) {
+            currentMultiStepForm.forEach((form) => {
+              const relatedForm = forms.find(currentForm => currentForm.$instance.id === form.$instance.id);
+
+              relatedForm.instance.resetForm();
+            });
+          });
+        },
         onError: function(fieldName, error) {
           if (!error) {
             if (this.errors[fieldName]) {
@@ -1402,6 +1413,10 @@ Fliplet().then(function() {
             }).then(function() {
               if (data.saveProgress) {
                 localStorage.removeItem(progressKey);
+              }
+
+              if (data.isFormInSlide) {
+                $vm.resetMultiStepForm();
               }
 
               var operation = Promise.resolve();


### PR DESCRIPTION
### Product areas affected

Fliplet Form Builder

### What does this PR do?

Ensures that Prev buttons do not block navigation to the previous slide when required fields are incomplete, all data entered into the form fields is cleared after submitting the entire sequence of forms,  previous and next slide link actions don't lead the user to the end or beginning of the slider.

### JIRA ticket

[DEV-477](https://weboo.atlassian.net/browse/DEV-477)
[DEV-481](https://weboo.atlassian.net/browse/DEV-481)
[DEV-484](https://weboo.atlassian.net/browse/DEV-484)

[DEV-477]: https://weboo.atlassian.net/browse/DEV-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-481]: https://weboo.atlassian.net/browse/DEV-481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-484]: https://weboo.atlassian.net/browse/DEV-484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ