### PR TITLE
PS-690 [FIX] validate comma is not present in decimal numbers

### DIFF
--- a/js/components/number.js
+++ b/js/components/number.js
@@ -72,6 +72,7 @@ Fliplet.FormBuilder.field('number', {
           if (!decimal.test(value)) {
             return false;
           }
+
           value = parseFloat(value);
 
           if (_.isNaN(value)) {

--- a/js/components/number.js
+++ b/js/components/number.js
@@ -63,7 +63,7 @@ Fliplet.FormBuilder.field('number', {
           value: maxNumbersAfterPoint
         },
         function(value) {
-          var decimal = /^(-?\d+((\.|\,)\d{1,10})?)$/;
+          var decimal = /^(-?\d+((\.)\d{1,10})?)$/;
 
           if (!value) {
             return true;
@@ -72,8 +72,6 @@ Fliplet.FormBuilder.field('number', {
           if (!decimal.test(value)) {
             return false;
           }
-
-          value = value.replace(',', '.');
           value = parseFloat(value);
 
           if (_.isNaN(value)) {


### PR DESCRIPTION
**Product areas affected**

Fliplet Form Builder

**What does this PR do?**

Validate commas are not present in the numbers form field when decimal numbers are configured.

**JIRA ticket**

[PS-690](https://weboo.atlassian.net/browse/DEV-690)

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None

[PS-690]: https://weboo.atlassian.net/browse/PS-690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ