### PR TITLE
PS-508 [FIX] move geolocation field to location & map category

### DIFF
--- a/js/components/geolocation.js
+++ b/js/components/geolocation.js
@@ -1,6 +1,6 @@
 Fliplet.FormBuilder.field('geolocation', {
   name: 'Geolocation',
-  category: 'Advanced',
+  category: 'Location & Map',
   props: {
     value: {
       type: Array,


### PR DESCRIPTION
**Product areas affected**

Fliplet Form Builder

**What does this PR do?**

Moves the Geolocation field from the Advanced category to the Location & Map category in the components accordion.

**JIRA ticket**

[DEV-508](https://weboo.atlassian.net/browse/DEV-508)

**Checklist**

None

**Testing instructions**

None

**Deployment instructions**

None

**Author concerns**

None


[PS-508]: https://weboo.atlassian.net/browse/PS-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEV-508]: https://weboo.atlassian.net/browse/DEV-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ