### PR TITLE
PS-207 [FIX] Ensure values are set in typeahead field when not present in initial options

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -116,6 +116,14 @@ function setTypeaheadFieldValue(field, value) {
       field.value = value;
     });
   } else {
+    value.forEach((val) => {
+      const exists = field.options.some(option => option.id === val);
+
+      if (!exists) {
+        field.options.push({ id: val, label: val });
+      }
+    });
+
     field.value = value;
   }
 }


### PR DESCRIPTION
**Product areas affected**

Fliplet Form Builder -> Type Ahead Field

**What does this PR do?**

Ensures the values are set and options array is updated accordingly in the typeahead field, when values are set through custom code using FormBuilder's JS API.

**JIRA ticket**

[DEV-207](https://weboo.atlassian.net/browse/DEV-207)


[DEV-207]: https://weboo.atlassian.net/browse/DEV-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ