### PR TITLE
PS-1048 [FIX] Ensures the form field is pulling data from DS when editing an existing entry.

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -2389,5 +2389,3 @@ Fliplet.FormBuilder.getAll = function(name) {
     });
   });
 };
-
-


### PR DESCRIPTION
### Product areas affected

Fliplet Form Builder

### What does this PR do?

Ensures the form field is pulling data from DS when editing an existing entry.

### JIRA ticket

[PS-1048](https://weboo.atlassian.net/browse/PS-1048 )
[PS-1060](https://weboo.atlassian.net/browse/PS-1060 )

[PS-1048]: https://weboo.atlassian.net/browse/PS-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PS-1060]: https://weboo.atlassian.net/browse/PS-1060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ