### PR TITLE
PS-1030 [Fix] Updated widget.json to include data-source references within fields

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -183,6 +183,7 @@
   "references": [
     "linkAction.page:page",
     "fields.$.mediaFolderId:mediaFolder",
+    "fields.$.dataSourceId:dataSource",
     "dataSourceId:dataSource"
   ]
 }


### PR DESCRIPTION
### What does this PR do?
Updates widget.json file to include references to data-source within field settings. Since, typeahead field itself needs a Data Source specified, widget.references should be responsible to tell backend to update fields DS references as well.
 
### JIRA Ticket
[PS-1030](https://weboo.atlassian.net/browse/PS-1030)