### PR TITLE
PS-1109 [Fix] Ensure custom height and width has default values before being sent to camera plugin

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -202,8 +202,8 @@ Fliplet.FormBuilder.field('image', {
           quality: $vm.jpegQuality,
           destinationType: Camera.DestinationType.DATA_URL,
           sourceType: $vm.cameraSource,
-          targetWidth: $vm.customWidth,
-          targetHeight: $vm.customHeight,
+          targetWidth: $vm.customWidth || 0, // Setting default value as 0 so that camera plugin API does not fail
+          targetHeight: $vm.customHeight || 0,
           popoverOptions: popoverOptions,
           encodingType: Camera.EncodingType.JPEG,
           mediaType: Camera.MediaType.PICTURE,


### PR DESCRIPTION
### What does this PR do?
This PR sets custom height and width to 0 as default when user has not specified it in the form component settings.

### JIRA ticket
[PS-1109](https://weboo.atlassian.net/browse/PS-1109)

[PS-1109]: https://weboo.atlassian.net/browse/PS-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ