### PR TITLE
Cache organization name to avoid duplicate API call

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -1424,9 +1424,19 @@ Fliplet().then(function() {
         $vm.initDataSourceProvider();
       }
 
-      Fliplet.Organizations.get().then(function(organizations) {
-        $vm.organizationName = organizations.length && organizations[0].name;
-      });
+      var cachedName = sessionStorage.getItem('fl-organization-name');
+
+      if (cachedName) {
+        $vm.organizationName = cachedName;
+      } else {
+        Fliplet.Organizations.get().then(function(organizations) {
+          $vm.organizationName = organizations.length && organizations[0].name;
+
+          if ($vm.organizationName) {
+            sessionStorage.setItem('fl-organization-name', $vm.organizationName);
+          }
+        });
+      }
 
       Fliplet.Widget.onSaveRequest(function() {
         if (window.emailTemplateAddProvider) {


### PR DESCRIPTION
## Summary
- cache organization name in sessionStorage to prevent repeated `Fliplet.Organizations.get()` requests after widget reloads

## Testing
- `npm run eslint:github-action` *(fails: ESLint couldn't find config)*

Ticket: [PR-48](https://weboo.atlassian.net/browse/PR-48)
------
https://chatgpt.com/codex/tasks/task_e_685536e90ca88330a09cc59a96b527ef

[PR-48]: https://weboo.atlassian.net/browse/PR-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ