### PR TITLE
Fix binary image upload

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -246,16 +246,19 @@ Fliplet.FormBuilder.field('image', {
           $vm.isImageSizeExceeded = false;
 
           var scaledImage = loadImage.scale(img, options);
-          var imgBase64Url = scaledImage.toDataURL(mimeType, $vm.jpegQuality);
-          var flipletBase64Url = imgBase64Url + ';filename:' + file.name;
 
-          $vm.value.push(flipletBase64Url);
+          scaledImage.toBlob(function(blob) {
+            blob.name = file.name;
+            $vm.value.push(blob);
 
-          if (addThumbnail) {
-            addThumbnailToCanvas(flipletBase64Url, $vm.value.length - 1, $vm);
-          }
+            if (addThumbnail) {
+              var imgBase64Url = scaledImage.toDataURL(mimeType, $vm.jpegQuality);
 
-          $vm.$emit('_input', $vm.name, $vm.value);
+              addThumbnailToCanvas(imgBase64Url, $vm.value.length - 1, $vm);
+            }
+
+            $vm.$emit('_input', $vm.name, $vm.value);
+          }, mimeType, $vm.jpegQuality / 100);
         });
       });
     },
@@ -295,7 +298,21 @@ Fliplet.FormBuilder.field('image', {
           ? imgBase64Url
           : 'data:image/jpeg;base64,' + imgBase64Url;
 
-        $vm.value.push(imgBase64Url);
+        var arr = imgBase64Url.split(',');
+        var mime = arr[0].match(/:(.*?);/)[1];
+        var bstr = atob(arr[1]);
+        var n = bstr.length;
+        var u8arr = new Uint8Array(n);
+
+        while (n--) {
+          u8arr[n] = bstr.charCodeAt(n);
+        }
+
+        var blob = new Blob([u8arr], { type: mime });
+
+        blob.name = 'image-' + Date.now() + '.' + mime.split('/')[1];
+
+        $vm.value.push(blob);
         addThumbnailToCanvas(imgBase64Url, $vm.value.length - 1, $vm);
         $vm.$emit('_input', $vm.name, $vm.value);
       }).catch(function(error) {
@@ -314,8 +331,12 @@ Fliplet.FormBuilder.field('image', {
     },
     onImageClick: function(index) {
       var imagesData = {
-        images: _.map(this.value, function(imgURL) {
-          return { url: imgURL };
+        images: _.map(this.value, function(img) {
+          if (img instanceof Blob) {
+            return { url: URL.createObjectURL(img) };
+          }
+
+          return { url: img };
         }),
         options: {
           index: index

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -46,11 +46,13 @@ function drawImageOnCanvas(img, canvas) {
 function addThumbnailToCanvas(imageURI, indexCanvas, self, isFileCanvas) {
   var $vm = self;
 
-  if (!imageURI.match(/^http/)) {
+  if (imageURI instanceof Blob) {
+    imageURI = URL.createObjectURL(imageURI);
+  } else if (!imageURI.match(/^http/) && imageURI.indexOf('data:') !== 0 && imageURI.indexOf('blob:') !== 0) {
     imageURI = (imageURI.indexOf('base64') > -1)
       ? imageURI.split(';filename:')[0]
       : 'data:image/jpeg;base64,' + imageURI;
-  } else {
+  } else if (imageURI.match(/^http/)) {
     imageURI = Fliplet.Media.authenticate(imageURI);
   }
 
@@ -1506,7 +1508,7 @@ Fliplet().then(async function() {
                   }
                 }
 
-                if (type === 'flFile') {
+                if (type === 'flFile' || type === 'flImage') {
                   var result = _.map(value, function(val) {
                     if (!val) {
                       return '';


### PR DESCRIPTION
## Summary
- write binary image data instead of base64
- handle preview with file objects
- allow form processor to treat images like files

## Testing
- `npm run eslint:github-action`

------
https://chatgpt.com/codex/tasks/task_e_6880ba97c6b083328a0e98810d6c41d1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image handling by storing uploaded images as files rather than base64 strings.
  * Enhanced compatibility for images captured via camera, now stored as files.

* **Bug Fixes**
  * Improved image preview and thumbnail generation for both uploaded and captured images.

* **Chores**
  * Normalised image and file data handling during form submission for greater consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->