### PR TITLE
Add comprehensive JSDoc and template documentation (#799)

### DIFF
--- a/js/components/buttons.js
+++ b/js/components/buttons.js
@@ -1,6 +1,15 @@
 /**
- * Buttons field component – renders form action buttons (Submit/Clear).
- * Configurable button labels and visibility options.
+ * @fileoverview Buttons field – renders form action buttons (Submit / Clear) for Fliplet forms.
+ *
+ * @component ButtonsField
+ * @vue-prop {Boolean} showLabel   – Toggle label visibility (default `false`).
+ * @vue-prop {Boolean} showSubmit  – Toggle Submit button (default `true`).
+ * @vue-prop {Boolean} showClear   – Toggle Clear button (default `true`).
+ * @vue-prop {String}  submitValue – Submit button label (default `'Submit'`).
+ * @vue-prop {String}  clearValue  – Clear button label (default `'Clear'`).
+ * @vue-prop {String}  submitType  – Submit button HTML type attribute (default `'submit'`).
+ * @vue-prop {String}  clearType   – Clear button HTML type attribute (default `'button'`).
+ * @vue-prop {String}  type        – Component type identifier (default `'flButtons'`).
  */
 Fliplet.FormBuilder.field('buttons', {
   name: 'Form buttons',

--- a/js/components/checkbox.js
+++ b/js/components/checkbox.js
@@ -1,6 +1,13 @@
 /**
- * Checkbox field component – renders multiple checkbox options in forms.
- * Supports multi-select functionality and "select all" option.
+ * Checkbox field component.
+ *
+ * @component checkbox
+ * @category Multiple options
+ * @description Renders a list of checkboxes with optional “Select all”.
+ * @prop {Array}   value        Selected option values
+ * @prop {String}  defaultValue Initial value(s) separated by newline
+ * @prop {Array}   options      Array<{label,id}>
+ * @prop {Boolean} addSelectAll Show a “Select all” checkbox
  */
 Fliplet.FormBuilder.field('checkbox', {
   name: 'Checkboxes (multi-select)',

--- a/js/components/codeScanner.js
+++ b/js/components/codeScanner.js
@@ -1,6 +1,7 @@
 /**
- * Code scanner field component – renders a barcode/QR code scanner in forms.
- * Captures and validates barcode data using device camera functionality.
+ * A Fliplet Form Builder field component that provides barcode/QR code scanning functionality.
+ * Allows users to scan barcodes or QR codes using their device's camera and automatically
+ * populate form fields with the scanned data.
  */
 Fliplet.FormBuilder.field('codeScanner', {
   name: 'Code scanner',

--- a/js/components/date.js
+++ b/js/components/date.js
@@ -1,6 +1,6 @@
 /**
  * Date field component – renders a date picker input in forms.
- * Supports date validation, format customization, and default value options.
+ * Supports date validation and default value options.
  */
 Fliplet.FormBuilder.field('date', {
   name: 'Date picker',

--- a/js/components/file.js
+++ b/js/components/file.js
@@ -2,7 +2,7 @@
 
 /**
  * File field component – renders a file upload input with progress tracking.
- * Supports multiple file types, image resizing, and media folder integration.
+ * Supports multiple file types and media folder integration.
  */
 Fliplet.FormBuilder.field('file', {
   i18n: window.VueI18Next,

--- a/js/components/horizontalRule.js
+++ b/js/components/horizontalRule.js
@@ -1,6 +1,6 @@
 /**
- * Horizontal rule field component – renders a visual separator line in forms.
- * Provides styling options for thickness, color, and spacing customization.
+- * Horizontal rule (LIne Break) field component – renders a visual separator line in forms.
++ * Horizontal rule (Line Break) field component – renders a visual separator line in forms.
  */
 Fliplet.FormBuilder.field('horizontalRule', {
   name: 'Line break',

--- a/js/components/image.js
+++ b/js/components/image.js
@@ -2,7 +2,7 @@
 
 /**
  * Image field component – renders an image capture and upload input in forms.
- * Supports camera capture, file upload, and image compression options.
+ * Supports camera capture, file upload.
  */
 Fliplet.FormBuilder.field('image', {
   i18n: window.VueI18Next,

--- a/js/components/matrix.js
+++ b/js/components/matrix.js
@@ -1,6 +1,6 @@
 /**
  * Matrix field component – renders a grid-based selection interface in forms.
- * Supports multiple rows and columns with radio or checkbox selection modes.
+ * Supports multiple rows and columns with radio selection mode.
  */
 Fliplet.FormBuilder.field('matrix', {
   name: 'Matrix',

--- a/js/components/number.js
+++ b/js/components/number.js
@@ -1,6 +1,14 @@
 /**
- * Number field component – renders a numeric input field with validation in forms.
- * Supports decimal precision, min/max constraints, and numeric formatting.
+ * Number field component.
+ *
+ * @component number
+ * @category Text inputs
+ * @description Renders a numeric input with built-in validators for
+ * integers, decimal precision and also has positive-only mode.
+ * @prop {String}  placeholder   Placeholder text
+ * @prop {Boolean} positiveOnly  Restrict input to ≥ 0
+ * @prop {Number}  decimals      Allowed decimal places
+ * @prop {String}  description   Additional helper text
  */
 Fliplet.FormBuilder.field('number', {
   i18n: window.VueI18Next,

--- a/js/components/password.js
+++ b/js/components/password.js
@@ -1,6 +1,10 @@
 /**
- * Password field component – renders a secure password input field in forms.
- * Supports password visibility toggle and confirmation field validation.
+ * This component provides a password input field with advanced features including:
+ * - Password strength validation with customizable rules
+ * - Password confirmation field
+ * - Auto-generation of secure passwords
+ * - Password hashing support
+ * - Progress saving and population on update
  */
 Fliplet.FormBuilder.field('password', {
   name: 'Password input',

--- a/js/components/radio.js
+++ b/js/components/radio.js
@@ -1,6 +1,14 @@
 /**
- * Radio field component – renders radio button options for single selection in forms.
- * Supports custom options and data source integration for dynamic choices.
+ * A single-select radio button component that allows users to choose one option from a list.
+ *
+ * @property {string} [description] - Optional description text displayed above the radio buttons
+ * @property {Array<Object>} options - Array of option objects with label and optional id properties
+ * @property {string} options[].label - Display text for the radio option
+ * @property {string} [options[].id] - Unique identifier for the option (optional, falls back to label)
+ * @property {boolean} [required=false] - Whether the field is required for form submission
+ * @property {boolean} [readonly=false] - Whether the field is read-only and cannot be modified
+ * @property {string} value - The currently selected option value (id or label)
+ *
  */
 Fliplet.FormBuilder.field('radio', {
   name: 'Radios (single-select)',

--- a/js/components/reorderList.js
+++ b/js/components/reorderList.js
@@ -1,6 +1,12 @@
 /**
- * Reorder list field component – renders a draggable list for item prioritization in forms.
- * Allows users to drag and drop items to establish custom ordering.
+ * @fileoverview Reorder-list field – draggable list for item prioritisation in Fliplet forms.
+ *
+ * Users can drag to establish custom ordering.
+ *
+ * @component ReorderListField
+ * @vue-prop {Array<Object>} options       – Default list items (`id`, `label`).
+ * @vue-prop {String}        optionsType   – 'dataSource' or 'static'.
+ * @vue-prop {Number}        dataSourceId  – Linked data-source ID when `optionsType` is 'dataSource'.
  */
 Fliplet.FormBuilder.field('reorderList', {
   name: 'Reorder list',

--- a/js/components/telephone.js
+++ b/js/components/telephone.js
@@ -1,6 +1,5 @@
 /**
  * Telephone field component – renders a phone number input with validation in forms.
- * Supports international formats, country code selection, and automatic formatting.
  */
 Fliplet.FormBuilder.field('telephone', {
   name: 'Telephone input',

--- a/js/components/textarea.js
+++ b/js/components/textarea.js
@@ -1,6 +1,6 @@
 /**
  * Textarea field component – renders a multi-line text input field in forms.
- * Supports configurable rows, character limits, and text validation.
+ * Supports configurable rows, character limits, and validation in case the field is required.
  */
 Fliplet.FormBuilder.field('textarea', {
   name: 'Multiple line input',

--- a/js/components/time.js
+++ b/js/components/time.js
@@ -1,6 +1,5 @@
 /**
  * Time field component – renders a time picker input for selecting hours and minutes.
- * Supports 12/24 hour formats and time validation constraints.
  */
 Fliplet.FormBuilder.field('time', {
   name: 'Time picker',

--- a/js/components/timer.js
+++ b/js/components/timer.js
@@ -1,6 +1,6 @@
 /**
- * Timer field component – renders a countdown timer display in forms.
- * Supports duration tracking and automatic form actions upon timer completion.
+ * This component renders a stopwatch or countdown timer input.
+ * It can start automatically, track elapsed or remaining time, and store the value persistently.
  */
 Fliplet.FormBuilder.field('timer', {
   name: 'Timer',

--- a/js/components/title.js
+++ b/js/components/title.js
@@ -1,6 +1,5 @@
 /**
  * Title field component – renders formatted heading text in forms.
- * Supports multiple heading levels and custom styling for form section headers.
  */
 Fliplet.FormBuilder.field('title', {
   name: 'Format Title',

--- a/js/components/typeahead.js
+++ b/js/components/typeahead.js
@@ -1,6 +1,6 @@
 /**
- * Typeahead field component – renders an autocomplete search input in forms.
- * Provides real-time search suggestions as users type with data source integration.
+ * This component renders a typeahead (autocomplete) input that supports multi-selection.
+ * Options can be configured manually or fetched from a data source.
  */
 Fliplet.FormBuilder.field('typeahead', {
   name: 'Typeahead (multi-select)',

--- a/js/components/url.js
+++ b/js/components/url.js
@@ -1,6 +1,5 @@
 /**
  * URL field component – renders a URL input field with validation in forms.
- * Validates URL format and provides protocol handling for web links.
  */
 Fliplet.FormBuilder.field('url', {
   name: 'URL input',

--- a/js/components/wysiwyg.js
+++ b/js/components/wysiwyg.js
@@ -1,6 +1,8 @@
 /**
- * WYSIWYG field component – renders a rich text editor with formatting tools in forms.
- * Supports HTML content creation with text styling, links, and embedded media.
+ * WYSIWYG field component - Renders a rich text editor powered by TinyMCE that allows users to create and edit
+ * formatted HTML content within forms. Supports text styling, links, tables, lists,
+ * and various formatting options with a comprehensive toolbar interface.
+ *
  */
 Fliplet.FormBuilder.field('wysiwyg', {
   name: 'Rich text',

--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -1,10 +1,17 @@
 /**
- * builder.js – Fliplet Form Builder: Studio-side logic for configuring forms.
+ * @fileoverview Form Builder Widget - Main Builder Interface
  *
- * Handles widget initialization, parent lookup, field migration, UI observers,
- * and Vue instance for the builder interface.
+ * It provides a comprehensive interface for creating, configuring, and managing form widgets
+ * within the Fliplet Studio environment.
  *
- * All exported functions and major logic blocks are documented with JSDoc.
+ * @description
+ * The Form Builder widget allows users to:
+ * - Create and configure form fields with various input types
+ * - Set up data sources for form submissions
+ * - Configure email notifications and templates
+ * - Manage form templates and layouts
+ * - Handle multi-step forms within slider containers
+ * - Configure access rules and security settings
  */
 
 /* eslint-disable eqeqeq */

--- a/js/libs/core.js
+++ b/js/libs/core.js
@@ -1,9 +1,14 @@
 /**
- * core.js – Fliplet Form Builder: Core utility functions and event hub.
+ * Main file for managing form components, events, and configurations in Fliplet Form Builder
  *
- * Provides shared logic for field management, event handling, and data helpers.
+ * This file provides a comprehensive form building system with the following capabilities:
+ * - Component registration and management
+ * - Event handling and communication
+ * - Form field configuration and validation
+ * - Multi-step form support
+ * - Data source integration
+ * - Template management
  *
- * All exported functions and major logic blocks are documented with JSDoc.
  */
 
 /* eslint-disable eqeqeq */

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -1,9 +1,7 @@
 /**
  * form.js – Fliplet Form Builder: Runtime form logic and helpers.
- *
  * Handles form rendering, validation, submission, and data integration.
  *
- * All exported functions and major logic blocks are documented with JSDoc.
  */
 
 var formBuilderInstances = [];

--- a/js/libs/templates.js
+++ b/js/libs/templates.js
@@ -1,8 +1,9 @@
 /**
- * templates.js – Fliplet Form Builder: Template helpers.
+ * This module manages form templates for the Fliplet Form Builder widget.
+ * It provides both system templates (built-in) and organization-specific templates
+ * that can be retrieved from the Fliplet API.
  *
  * Provides utility functions for working with Handlebars templates.
- *
  * All exported functions and major logic blocks are documented with JSDoc.
  */
 


### PR DESCRIPTION
PR: https://github.com/Fliplet/fliplet-widget-form-builder/pull/799

* Add comprehensive JSDoc and template documentation

- Add JSDoc headers to all Vue components in js/components/
- Add JSDoc header to password configuration component
- Add template comments to 12 complex Handlebars templates
- Update README.md to include documentation step in field creation process
- Improve code maintainability and AI agent comprehension

🤖 Generated with [Claude Code](https://claude.ai/code)



* Update address.js

* Update address.js

* Update buttons.js

* Update js/components/checkbox.js



* Update js/components/buttons.js



* Update codeScanner.js

* Update date.js

* Update file.js

* Update horizontalRule.js

* Update image.js

* Update matrix.js

* Update js/components/number.js



* Update number.js

* Update password.js

* Update radio.js

* Update js/components/reorderList.js



* Update telephone.js

* Update textarea.js

* Update time.js

* Update timer.js

* Update title.js

* Update typeahead.js

* Update url.js

* Update wysiwyg.js

* Update builder.js

* Update core.js

* Update form.js

* Update templates.js

* Update README.md

* Update README.md

* Update js/components/number.js



* Update js/components/horizontalRule.js



* fix ESLint error

---------