### PR TITLE
PS-1170 [FIX] update typeahead field's max limit behaviour

### DIFF
--- a/js/build.templates.js
+++ b/js/build.templates.js
@@ -267,7 +267,7 @@ this["Fliplet"]["Widget"]["Templates"]["templates.components.title"] = Handlebar
 },"useData":true});
 
 this["Fliplet"]["Widget"]["Templates"]["templates.components.typeahead"] = Handlebars.template({"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data) {
-    return "<template>\n  <div class=\"form-group fl-typeahead\" :class=\"{ 'readonly' : readonly }\" ref=\"typeahead\">\n    <select multiple placeholder=\"Start typing...\"></select>\n  </div>\n  <div class=\"text-danger\" v-if=\"reachedMaxItems\">Only {{maxItems}} item(s) can be selected.</div>\n</template>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">"
+    return "<template>\n  <div class=\"form-group fl-typeahead\" :class=\"{ 'readonly' : readonly }\" ref=\"typeahead\">\n    <select multiple placeholder=\"Start typing...\"></select>\n  </div>\n  <div v-if=\"maxItems && !exceededMaxItems\" class=\"help-block\">{{messages.maxItemsHelper}}</div>\n  <div v-if=\"exceededMaxItems\" class=\"text-danger\">{{messages.exceededMaxItems}}</div>\n</template>\n<p class=\"text-danger\" v-if=\"$v.value.required === false && $v.value.$dirty\">"
     + container.escapeExpression((helpers.T || (depth0 && depth0.T) || helpers.helperMissing).call(depth0 != null ? depth0 : (container.nullContext || {}),"widgets.form.errors.required",{"name":"T","hash":{},"data":data}))
     + "</p>\n";
 },"useData":true});

--- a/js/components/typeahead.js
+++ b/js/components/typeahead.js
@@ -57,14 +57,33 @@ Fliplet.FormBuilder.field('typeahead', {
   },
   data: function() {
     return {
-      typeahead: null
+      typeahead: null,
+      messages: {
+        exceededMaxItems: T('widgets.form.typeahead.errors.limitExceeded', { maxItems: this.maxItems }),
+        maxItemsHelper: T('widgets.form.typeahead.maxItemsHelper', { maxItems: this.maxItems })
+      }
     };
   },
   computed: {
+    /**
+     * Checks if the current selection exceeds the maximum allowed items
+     * @returns {boolean} True if the selection exceeds maxItems limit
+     */
+    exceededMaxItems: function() {
+      return this.maxItems && this.value && this.value.length > this.maxItems;
+    },
+    /**
+     * Checks if the current selection has reached the maximum allowed items
+     * @returns {boolean} True if the selection has reached or exceeded maxItems limit
+     */
     reachedMaxItems: function() {
-      return this.value && this.value.length === this.maxItems;
+      return this.maxItems && this.value && this.value.length >= this.maxItems;
     }
   },
+  /**
+   * Defines validation rules for the typeahead field
+   * @returns {Object} Validation rules object
+   */
   validations: function() {
     var rules = {
       value: {}
@@ -74,8 +93,16 @@ Fliplet.FormBuilder.field('typeahead', {
       rules.value.required = window.validators.required;
     }
 
+    if (this.maxItems) {
+      rules.value.maxLength = window.validators.maxLength(this.maxItems);
+    }
+
     return rules;
   },
+  /**
+   * Initializes default values and sets up form submission hooks
+   * @returns {void}
+   */
   created: function() {
     if (!!this.defaultValue && this.optionsType === 'manual') {
       this.value = this.defaultValue.split(/\n/);
@@ -87,9 +114,17 @@ Fliplet.FormBuilder.field('typeahead', {
 
     Fliplet.Hooks.on('beforeFormSubmit', this.onBeforeSubmit);
   },
+  /**
+   * Cleans up event listeners to prevent memory leaks
+   * @returns {void}
+   */
   destroyed: function() {
     Fliplet.Hooks.off('beforeFormSubmit', this.onBeforeSubmit);
   },
+  /**
+   * Initializes the typeahead functionality and sets up default values
+   * @returns {void}
+   */
   mounted: function() {
     if (this.defaultValueSource !== 'default') {
       this.setValueFromDefaultSettings({
@@ -103,6 +138,11 @@ Fliplet.FormBuilder.field('typeahead', {
     this.$emit('_input', this.name, this.value, false, true);
   },
   methods: {
+    /**
+     * Initializes the typeahead component with configuration options
+     * Sets up event listeners and handles initial state
+     * @returns {void}
+     */
     initTypeahead: function() {
       var $vm = this;
 
@@ -115,7 +155,6 @@ Fliplet.FormBuilder.field('typeahead', {
         value: this.value,
         options: this.options,
         freeInput: this.freeInput,
-        maxItems: this.maxItems,
         placeholder: this.placeholder,
         order: this.optionsType === 'dataSource' ? 'asc' : null
       });
@@ -123,24 +162,58 @@ Fliplet.FormBuilder.field('typeahead', {
       this.typeahead.change(function(value) {
         $vm.value = value;
         $vm.updateValue();
+        $vm.handleMaxItemsLock();
       });
+
+      // Check if initial value already reaches maxItems limit
+      this.handleMaxItemsLock();
     },
+    /**
+     * Handles locking/unlocking the typeahead based on maxItems limit
+     * Prevents further selection when the limit is reached
+     * @returns {void}
+     */
+    handleMaxItemsLock: function() {
+      if (!this.typeahead || !this.maxItems) {
+        return;
+      }
+
+      if (this.reachedMaxItems) {
+        this.typeahead.lock();
+      } else {
+        this.typeahead.unlock();
+      }
+    },
+    /**
+     * Hook called before form submission
+     * Ensures the current typeahead value is captured for submission
+     * @returns {void}
+     */
     onBeforeSubmit: function() {
       this.value = this.typeahead.get();
     }
   },
   watch: {
+    /**
+     * Watches for changes in the value prop
+     * Updates the typeahead component and handles max items locking
+     * @param {Array} val - The new value array
+     * @returns {void}
+     */
     value: function(val) {
-      if (this.maxItems && val.length > this.maxItems) {
-        val = val.slice(0, this.maxItems);
-      }
-
       if (this.typeahead) {
         this.typeahead.set(val);
       }
 
+      this.handleMaxItemsLock();
       this.$emit('_input', this.name, val);
     },
+    /**
+     * Watches for changes in the options prop
+     * Updates the typeahead component with new options
+     * @param {Array} val - The new options array
+     * @returns {void}
+     */
     options: function(val) {
       if (this.typeahead) {
         this.typeahead.options(val);

--- a/templates/components/typeahead.build.hbs
+++ b/templates/components/typeahead.build.hbs
@@ -3,7 +3,8 @@
   <div class="form-group fl-typeahead" :class="{ 'readonly' : readonly }" ref="typeahead">
     <select multiple placeholder="Start typing..."></select>
   </div>
-  <div class="text-danger" v-if="reachedMaxItems">Only \{{maxItems}} item(s) can be selected.</div>
+  <div v-if="maxItems && !exceededMaxItems" class="help-block">\{{messages.maxItemsHelper}}</div>
+  <div v-if="exceededMaxItems" class="text-danger">\{{messages.exceededMaxItems}}</div>
 </template>
 <p class="text-danger" v-if="$v.value.required === false && $v.value.$dirty">{{T
     "widgets.form.errors.required"

--- a/translation.json
+++ b/translation.json
@@ -127,6 +127,12 @@
       "customButton": {
         "defaultError": "Error encountered with '{{label}}' button"
       },
+      "typeahead": {
+        "maxItemsHelper": "Max {{maxItems}} item(s).",
+        "errors": {
+          "limitExceeded": "Only {{maxItems}} item(s) can be selected."
+        }
+      },
       "telephone": {
         "instruction": "Phone number can only contain <b>; , . ( ) - + SPACE * #</b> and numbers."
       },


### PR DESCRIPTION
### Product areas affected

Fliplet Form Builder -> Typeahead Field

### What does this PR do?

Enusres initial selected values are not truncated when they exceed the max limit.
Ensures the error message only appears when selected values exceed the max limit.

### JIRA ticket

[PS-1170](https://weboo.atlassian.net/browse/PS-1170)

### Dependencies

This PR is dependent on changes to the typeahead JS API done as part of the same ticket.

### Result

[Demo Video](https://www.loom.com/share/d3da3405fe4041fbb669f71d0d8f6760?sid=14b2e920-a747-4926-84ed-6cca357c4917)