### PR TITLE
PS-1205 [FIX] configure email hooks separately for each widget instance

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -490,19 +490,14 @@ Fliplet().then(function() {
 
             operation = Fliplet.DataSources.getById($vm.settings.dataSourceId).then(function(dataSource) {
               // First check if any email hook exists
-              var emailHookExists = dataSource.hooks.some(function(hook) {
-                return hook.type === 'email';
+              var emailHook = dataSource.hooks.find(function(hook) {
+                return hook.type === 'email' && hook.widgetInstanceId === widgetId && hook.runOn.includes('insert');
               });
 
-              if (emailHookExists) {
-                // Update existing email hooks
-                dataSource.hooks.forEach(function(hook) {
-                  if (hook.type === 'email') {
-                    hook.payload = payload;
-                    hook.widgetInstanceId = widgetId;
-                    hook.triggers = [widgetUuid];
-                  }
-                });
+              if (emailHook) {
+                // Update existing email hook
+                emailHook.payload = payload;
+                emailHook.triggers = [widgetUuid];
               } else {
                 // Add new hook only if no email hook exists
                 dataSource.hooks.push({
@@ -563,19 +558,14 @@ Fliplet().then(function() {
 
             operation = Fliplet.DataSources.getById($vm.settings.dataSourceId).then(function(dataSource) {
               // First check if any email hook exists
-              var emailHookExists = dataSource.hooks.some(function(hook) {
-                return hook.type === 'email';
+              var emailHook = dataSource.hooks.find(function(hook) {
+                return hook.type === 'email' && hook.widgetInstanceId === widgetId && hook.runOn.includes('update');
               });
 
-              if (emailHookExists) {
-                // Update existing email hooks
-                dataSource.hooks.forEach(function(hook) {
-                  if (hook.type === 'email') {
-                    hook.payload = payload;
-                    hook.widgetInstanceId = widgetId;
-                    hook.triggers = [widgetUuid];
-                  }
-                });
+              if (emailHook) {
+                // Update existing email hook
+                emailHook.payload = payload;
+                emailHook.triggers = [widgetUuid];
               } else {
                 // Add new hook only if no email hook exists
                 dataSource.hooks.push({


### PR DESCRIPTION
### Product areas affected

Fliplet Form Builder -> Form DS Hooks

### What does this PR do?

Ensures each widget instance has its own email hook.

### JIRA ticket

[PS-1205](https://weboo.atlassian.net/browse/PS-1205)

### Notes 

The ticket requires changes on the fliplet-api to remove hooks when a widget instance is deleted.

[PS-1205]: https://weboo.atlassian.net/browse/PS-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Email notification setup now targets only the specific widget being configured, preventing unintended changes to other widgets.
  - Triggers are correctly scoped to the chosen widget and action (create/update), improving reliability and preventing unexpected emails.
  - Ensures consistent behaviour in multi-widget projects while maintaining expected data source updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->