### PR TITLE
PS-1079 [FIX] Update warning formatting

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -321,7 +321,7 @@ Fliplet().then(function() {
 
         const fieldNames = misconfiguredFields.map(f => escapeHtml(f.name)).join(', ');
 
-        return T('widgets.form.warningLabel') + T('widgets.form.mediaWarning', { fieldNames });
+        return `<b>${T('widgets.form.warningLabel')}: </b> ${T('widgets.form.mediaWarning', { fieldNames })}`;
       },
       missingColumns: function() {
         return this.newColumns.join(', ');


### PR DESCRIPTION
### Product areas affected

Fliplet Form Builder

### What does this PR do?

Updates media warning label formatting to be bold.

### JIRA ticket

[PS-1079](https://weboo.atlassian.net/browse/PS-1079)

[PS-1079]: https://weboo.atlassian.net/browse/PS-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the visual presentation of media-related warning messages: the warning label is now bold and followed by a colon for clearer emphasis.
  - Enhances readability and scannability of warnings in forms, especially when multiple fields are affected.
  - No changes to behaviour or functionality; this is a visual update only.
  - Aligns warning styling with broader UI conventions for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->