### PR TITLE
PS-1694: Add fliplet-media to interface dependencies

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -18,6 +18,7 @@
       "fliplet-ui-rangeslider",
       "fliplet-ui-typeahead",
       "fliplet-datasources",
+      "fliplet-media",
       "fliplet-barcode",
       "codemirror",
       "bootstrap",


### PR DESCRIPTION
## Summary
- Added `fliplet-media` to interface dependencies in `widget.json`
- Fixes `TypeError: Cannot read properties of undefined (reading 'getAll')` when opening Form Builder configuration in Studio

## Root Cause
The `file.js` component calls `Fliplet.Media.Files.getAll()` in its `mounted()` hook (added in commit `77f6cf43` on April 1, 2024 for ID-4193). However, `fliplet-media` was only included in **build** dependencies, not **interface** dependencies, causing the error in Studio.

## Test plan
- [ ] Open Studio → open a screen with Form Builder
- [ ] Proceed to Component Settings
- [ ] Click on "Add Field"
- [ ] Verify no `getAll` TypeError in console
- [ ] Verify file field works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)