### PR TITLE
PS-1694: Fix slider parent variable typos and null checks

### DIFF
--- a/js/libs/builder.js
+++ b/js/libs/builder.js
@@ -37,8 +37,8 @@ Fliplet.Widget.findParents({ instanceId: widgetId }).then(function(parents) {
     parent.package === 'com.fliplet.slider-container' || parent.name === 'Slider container'
   );
 
-  data.slideId = formSlideParent.length && formSlideParent.slideId;
-  data.sliderContainerId = formSliderParent.length && formSliderParent.sliderId;
+  data.slideId = formSlideParent && formSlideParent.slideId;
+  data.sliderContainerId = formSliderParent && formSliderParent.sliderId;
   isFormInSlider = !!(formSlideParent && formSlideParent.slideId);
 });
 
@@ -1073,8 +1073,8 @@ Fliplet().then(function() {
               parent.package === 'com.fliplet.slider-container' || parent.name === 'Slider container'
             );
 
-            widget.isFormInSlider = !!(formSliderParent && formSliderParent.slideId);
-            widget.sliderContainerId = formSliderParent.length && formSliderParent.sliderId;
+            widget.isFormInSlider = !!(formSliderParent && formSliderParent.sliderId);
+            widget.sliderContainerId = formSliderParent && formSliderParent.sliderId;
 
             return widget;
           } catch (error) {

--- a/js/libs/core.js
+++ b/js/libs/core.js
@@ -1118,10 +1118,10 @@ Fliplet.FormBuilder = (function() {
               parent.package === 'com.fliplet.slider-container' || parent.name === 'Slider container'
             );
 
-            widget.isFormInSlider = !!(formSliderParent && formSliderParent.slideId);
+            widget.isFormInSlider = !!(formSliderParent && formSliderParent.sliderId);
 
-            widget.sliderContainerId = formSliderParent.length && formSliderParent.sliderId;
-            widget.slideId = widget.sldieId;
+            widget.sliderContainerId = formSliderParent && formSliderParent.sliderId;
+            widget.slideId = widget.slideId;
 
             return widget;
           } catch (error) {


### PR DESCRIPTION
## Summary
- Fix TypeError when Form is not inside a Slider container (discovered by QA after PR #867 fix)
- Fix variable typos and incorrect `.length` checks on Objects returned by `.find()`

## Changes
- **builder.js (line 40-41):** Replace `.length` check with null check on `formSlideParent` and `formSliderParent`
- **builder.js (line 1076-1077):** Fix `formSliderParent.slideId` → `.sliderId`, replace `.length` with null check
- **core.js (line 1121-1124):** Fix `.slideId` → `.sliderId`, `.length` → null check, `sldieId` → `slideId` typo

## Root Cause
`.find()` returns an Object or `undefined`, not an array. Using `.length` on `undefined` throws TypeError. Previously masked by the `getAll` error fixed in PR #867.

## Testing
- Open Form Builder in Studio
- Add a field to a form that is NOT inside a Slider container
- Verify no TypeError in console

Co-Authored-By: Claude <noreply@anthropic.com>