### PR TITLE
fix: handle object-type image values in canvas rendering (PS-1420)

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -436,6 +436,11 @@ Fliplet.FormBuilder.field('image', {
             return { url: URL.createObjectURL(img) };
           }
 
+          // Handle image values stored as objects (e.g. { url: '...', name: '...' })
+          if (img && typeof img === 'object') {
+            return { url: img.url || '' };
+          }
+
           return { url: img };
         }),
         options: {

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -59,6 +59,15 @@ function dataURLToBlob(dataUrl) {
 function addThumbnailToCanvas(imageURI, indexCanvas, self, isFileCanvas) {
   const $vm = self;
 
+  // Handle image values stored as objects (e.g. { url: '...', name: '...' })
+  if (imageURI && typeof imageURI === 'object' && !(imageURI instanceof Blob)) {
+    imageURI = imageURI.url || '';
+  }
+
+  if (!imageURI) {
+    return;
+  }
+
   if (imageURI instanceof Blob) {
     imageURI = URL.createObjectURL(imageURI);
   } else if (!imageURI.match(/^http/) && imageURI.indexOf('data:') !== 0 && imageURI.indexOf('blob:') !== 0) {


### PR DESCRIPTION
## Summary
- Fixes `ERR_INVALID_URL` when images loaded from data sources are stored as objects (`{url: '...', name: '...'}`) instead of plain URL strings
- Updates both `addThumbnailToCanvas()` in form.js and `onImageClick()` in image.js to extract `.url` from object values
- Affects Events/Exhibitor forms where uploaded images fail to render

## Test plan
- [ ] Upload an image in a form field — should render normally (no regression)
- [ ] Load a form with exhibitor data containing image objects — should render correctly instead of showing broken image
- [ ] Click on a loaded image to preview — should open image preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)