### PR TITLE
release/DEV-819: Prevent swiping through slides with error messages

### DIFF
--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -745,8 +745,14 @@ Fliplet().then(async function() {
           action: function() {
             this.dismiss();
 
+            const shouldRefresh = !data.linkAction || data.redirect !== true;
+
             if (typeof onDismiss === 'function') {
               onDismiss();
+            }
+
+            if (shouldRefresh && typeof window !== 'undefined' && window.location) {
+              window.location.reload();
             }
           }
         }],

--- a/js/libs/form.js
+++ b/js/libs/form.js
@@ -708,6 +708,7 @@ Fliplet().then(async function() {
     }
 
     const changeListeners = {};
+    let hasBlockingError = false;
 
     /**
      * @function showSubmissionExistMessage
@@ -718,6 +719,21 @@ Fliplet().then(async function() {
      * @returns {void}
     */
     function showSubmissionExistMessage(columnName, value, onDismiss) {
+      hasBlockingError = true;
+
+      const swipers = document.querySelectorAll('.swiper-container');
+
+      if (swipers && swipers.length > 0) {
+        swipers.forEach(function(swiperEl) {
+          if (swiperEl.swiper) {
+            // Disable all navigation when error toast is shown
+            swiperEl.swiper.allowSlideNext = false;
+            swiperEl.swiper.allowSlidePrev = false;
+            swiperEl.swiper.allowTouchMove = false;
+          }
+        });
+      }
+
       Fliplet.UI.Toast({
         type: 'regular',
         position: 'center',
@@ -745,6 +761,21 @@ Fliplet().then(async function() {
      * @returns {void}
     */
     function showOfflineMessage() {
+      hasBlockingError = true;
+
+      const swipers = document.querySelectorAll('.swiper-container');
+
+      if (swipers && swipers.length > 0) {
+        swipers.forEach(function(swiperEl) {
+          if (swiperEl.swiper) {
+            // Disable all navigation when error toast is shown
+            swiperEl.swiper.allowSlideNext = false;
+            swiperEl.swiper.allowSlidePrev = false;
+            swiperEl.swiper.allowTouchMove = false;
+          }
+        });
+      }
+
       Fliplet.UI.Toast({
         type: 'regular',
         position: 'center',
@@ -2087,7 +2118,14 @@ Fliplet().then(async function() {
 
           function handleTouchStart(swiper) {
             isTouchMoveTriggered = false;
-            swiper.allowSlideNext = true;
+
+            if (hasBlockingError) {
+              swiper.allowSlideNext = false;
+              swiper.allowSlidePrev = false;
+              swiper.allowTouchMove = false;
+            } else {
+              swiper.allowSlideNext = true;
+            }
           }
 
           async function handleTouchMove(swiper, swiperContainer, data, allFormsInSlide, $vm) {
@@ -2110,10 +2148,17 @@ Fliplet().then(async function() {
             $vm.synchronizeMatchingFields(currentMultiStepForm, data, 'touchmove');
 
             setTimeout(() => {
-              const formsInActiveSlide = currentMultiStepForm.filter(form => form.$instance.slideId === activeSlideId);
-              const canSwipe = !formsInActiveSlide.some(form => form.$instance.isFormValid === false);
+              if (hasBlockingError) {
+                swiper.allowSlideNext = false;
+                swiper.allowSlidePrev = false;
+                swiper.allowTouchMove = false;
+              } else {
+                // Normal form validation behavior
+                const formsInActiveSlide = currentMultiStepForm.filter(form => form.$instance.slideId === activeSlideId);
+                const canSwipe = !formsInActiveSlide.some(form => form.$instance.isFormValid === false);
 
-              swiper.allowSlideNext = canSwipe;
+                swiper.allowSlideNext = canSwipe;
+              }
             }, 0);
           }
 


### PR DESCRIPTION
## [DEV-819](https://weboo.atlassian.net/browse/DEV-819): The user can swipe through slides with error message on the screen

**Parent ticket:** [DEV-473](https://weboo.atlassian.net/browse/DEV-473) - Single submission logic

### Changes

- [DEV-819](https://weboo.atlassian.net/browse/DEV-819) Disable swiper navigation (next, prev, touch) when a blocking error toast (duplicate submission or offline message) is shown, preventing users from swiping through slides while error messages are on screen
- [DEV-819](https://weboo.atlassian.net/browse/DEV-819) Reload the page when user clicks OK on the submission-exists toast, unless a redirect action is configured
- [DEV-819](https://weboo.atlassian.net/browse/DEV-819) Add `hasBlockingError` flag to persist swipe-disabled state through touchmove events so the swiper stays locked even after touch interactions

### Files Changed
- `js/libs/form.js` — Added swiper disable logic in `showSubmissionExistMessage()` and `showOfflineMessage()`, added page reload on OK dismiss, and integrated `hasBlockingError` check into the touchmove swiper validation

### Test Plan
- [ ] Multi-step form with single submission: submit once, trigger duplicate submission toast — verify slides cannot be swiped
- [ ] Click OK on the duplicate submission toast — verify page reloads
- [ ] Multi-step form with single submission + redirect configured — verify OK does NOT reload but follows redirect
- [ ] Offline scenario: trigger offline toast on multi-step form — verify slides cannot be swiped
- [ ] Normal multi-step form (no errors): verify swiping still works based on validation state
- [ ] Vertical scroll on slide component — verify it doesn't interfere with swipe lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEV-819]: https://weboo.atlassian.net/browse/DEV-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-473]: https://weboo.atlassian.net/browse/DEV-473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-819]: https://weboo.atlassian.net/browse/DEV-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-819]: https://weboo.atlassian.net/browse/DEV-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DEV-819]: https://weboo.atlassian.net/browse/DEV-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ