### PR TITLE
PS-1636 [Fix] typeahead crash when options change before value loads …

### DIFF
--- a/js/components/typeahead.js
+++ b/js/components/typeahead.js
@@ -260,10 +260,10 @@ Fliplet.FormBuilder.field('typeahead', {
      */
     options: function(val) {
       if (this.typeahead) {
-        this.typeahead.options(val, this.value);
+        this.typeahead.options(val, this.value || []);
       }
 
-      this.typeahead.set(this.value);
+      this.typeahead.set(this.value || []);
     },
     /**
      * Watches for changes in the readonly prop


### PR DESCRIPTION
**Product areas affected**

Fliplet Widget Form Builder

**What does this PR do?**

Fixes typeahead crash in edit mode when options are updated before the field value loads preventing users from adding items after deleting a selection.

**JIRA ticket**

[PS-1636](https://weboo.atlassian.net/browse/PS-1636)

[PS-1636]: https://weboo.atlassian.net/browse/PS-1636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ