### PR TITLE
PS-1978 [FIX] Ensures image upload doesn't open duplicate pickers

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -311,23 +311,20 @@ Fliplet.FormBuilder.field('image', {
         return;
       }
 
-      let getPicture;
-
+      // Re-entry from imageInput.click() in the PHOTOLIBRARY branch below — the
+      // native HTML file picker is about to open and onFileChange will deliver
+      // the result. Calling getPicture() here opens a second, orphan Cordova
+      // picker (no .then handler), which stacks on Android and leaks into the
+      // next tap on iOS (PS-1978).
       if (this.forcedClick) {
         this.forcedClick = false;
-
-        try {
-          getPicture = $vm.getPicture();
-        } catch (error) {
-          console.error('Failed to get picture', error);
-        }
 
         return;
       }
 
       event.preventDefault();
 
-      getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
+      const getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
         if ($vm.cameraSource === Camera.PictureSourceType.PHOTOLIBRARY) {
           $vm.forcedClick = true;
 


### PR DESCRIPTION
### Product areas affected
Form Builder widget — Image field on the native Portal app (iOS + Android). No effect on Studio preview or Web Live app.

### What does this PR do?
Fixes the Skadden image-upload failure on Portal. The `forcedClick` re-entry branch in `onFileClick` was calling `navigator.camera.getPicture()` alongside the programmatic HTML file-input click that just triggered it — opening a second, orphan Cordova picker with no `.then` handler. On Android this stacked two pickers (user had to pick the same photo twice); on iOS the orphan promise leaked into the next tap so the image was silently dropped on the second upload. The fix removes the redundant `getPicture()` call so the HTML picker is the sole source for the photo-library path; `onFileChange` continues to deliver the result.

### JIRA ticket
[PS-1978](https://weboo.atlassian.net/browse/PS-1978)

### Result
Test matrix to run on a real Portal build, both platforms:
- + Choose image → Take Photo → image attaches
- + Choose image → Choose Existing Photo (first tap) → image attaches
- + Choose image → Choose Existing Photo (second tap, back-to-back) → image attaches
- Cancel sheet A, then retry → flow resumes cleanly
- Studio preview / Web Live → no regression

### Checklist
 - [ ] Added automated test coverage as appropriate for this change.

### Deployment instructions
Standard widget release. No data or config migration required.

### Author concerns
- PS-1192 area has been reverted 3 times (PRs #812, #822, #830) — desk review is insufficient. Real-device gating on iOS + Android Portal builds is required before merge.
- A related units-mismatch bug at `image.js:268` (`$vm.jpegQuality || 0.8` where the prop defaults to 80, but `toBlob` expects 0–1) is **out of scope** for this PR. It causes WebP encodes to fall back to the browser default quality rather than 0.8. Consider as a follow-up.

[PS-1978]: https://weboo.atlassian.net/browse/PS-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ