### PR TITLE
PS-1978 [FIX] Route image PHOTOLIBRARY path through Cordova picker

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -311,35 +311,34 @@ Fliplet.FormBuilder.field('image', {
         return;
       }
 
-      // Re-entry from imageInput.click() in the PHOTOLIBRARY branch below — the
-      // native HTML file picker is about to open and onFileChange will deliver
-      // the result. Calling getPicture() here opens a second, orphan Cordova
-      // picker (no .then handler), which stacks on Android and leaks into the
-      // next tap on iOS (PS-1978).
-      if (this.forcedClick) {
-        this.forcedClick = false;
-
-        return;
-      }
-
       event.preventDefault();
 
-      const getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
-        if ($vm.cameraSource === Camera.PictureSourceType.PHOTOLIBRARY) {
-          $vm.forcedClick = true;
+      let getPicture;
 
-          // Use native element click so the OS file picker opens reliably
-          if ($vm.$refs.imageInput && typeof $vm.$refs.imageInput.click === 'function') {
-            $vm.$refs.imageInput.click();
-          } else {
+      // Re-entry from the jQuery trigger('click') in the PHOTOLIBRARY branch
+      // below. jQuery's trigger fires the JS click event without opening the
+      // browser's native file picker, so this branch is responsible for opening
+      // the Cordova picker and its result must flow through onSelectedPicture
+      // below — do NOT early-return here (PS-1978).
+      if (this.forcedClick) {
+        this.forcedClick = false;
+        getPicture = $vm.getPicture();
+      } else {
+        getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
+          if ($vm.cameraSource === Camera.PictureSourceType.PHOTOLIBRARY) {
+            $vm.forcedClick = true;
+
+            // jQuery trigger — re-enters onFileClick without opening the
+            // browser's native file picker (which is unreliable from this
+            // async context in Android WebView).
             $($vm.$refs.imageInput).trigger('click');
+
+            return Promise.reject('Switch to HTML file input to select files');
           }
 
-          return Promise.reject('Switch to HTML file input to select files');
-        }
-
-        return $vm.getPicture();
-      });
+          return $vm.getPicture();
+        });
+      }
 
       this.validateValue();
 


### PR DESCRIPTION
### Product areas affected
Form Builder widget — Image field on the native Portal app (iOS + Android). No effect on Studio preview or Web Live app. Follow-up to #877.

### What does this PR do?
Restores the pre-#836 design for the image field's photo-library flow. In #877 the orphan Cordova `getPicture()` was removed from the `forcedClick` re-entry branch, which eliminated the duplicate picker but left Android with a silently-failing HTML file picker: the programmatic `imageInput.click()` from a Promise microtask shows the picker but loses user activation in System WebView, so `onFileChange` never fires and the picked image is dropped without any error UI.

This PR swaps the native `imageInput.click()` back to `$(imageInput).trigger('click')` (jQuery — fires the JS click event only, does **not** open the browser's native file picker) and removes the early-`return` from the forcedClick branch. The re-entry now calls Cordova `getPicture()` and the result flows through the existing `onSelectedPicture` `.then` handler that attaches the image to the form. End result on PHOTOLIBRARY: one Cordova picker, no orphan promise, no HTML fallback path.

### JIRA ticket
[PS-1978](https://weboo.atlassian.net/browse/PS-1978)

### Result
Test matrix on a real Portal build, both platforms:
- + Choose image → Take Photo → image attaches
- + Choose image → Choose Existing Photo (first tap) → image attaches via Cordova picker, no second picker
- + Choose image → Choose Existing Photo (second tap, back-to-back) → image attaches; no iOS second-tap drop
- Cancel sheet A, then retry → flow resumes cleanly
- Studio preview / Web Live → no regression

### Checklist
 - [ ] Added automated test coverage as appropriate for this change.

### Deployment instructions
Standard widget release. No data or config migration required.

### Author concerns
- PS-1192 area has been reverted 3 times (PRs #812, #822, #830). #877 itself needed this follow-up. Real-device gating on iOS + Android Portal builds is required before merge — desk review is insufficient.
- The native `.click()` was introduced in #836 with the comment "so the OS file picker opens reliably". The intent was likely to support multi-image selection via the HTML picker, but it was never wired to actually consume HTML picker results in the PHOTOLIBRARY path — `onFileChange` exists but `processImage` is reached only via the Cordova chain in practice. Worth a follow-up if multi-image library selection is desired.
- A related units-mismatch bug at `image.js:268` (`$vm.jpegQuality || 0.8` where the prop defaults to 80 but `toBlob` expects 0–1) is **out of scope** here. Consider as a follow-up.

[PS-1978]: https://weboo.atlassian.net/browse/PS-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ