### PR TITLE
Release: release/PS-1978 → production

### DIFF
--- a/js/components/image.js
+++ b/js/components/image.js
@@ -311,35 +311,34 @@ Fliplet.FormBuilder.field('image', {
         return;
       }
 
-      // Re-entry from imageInput.click() in the PHOTOLIBRARY branch below — the
-      // native HTML file picker is about to open and onFileChange will deliver
-      // the result. Calling getPicture() here opens a second, orphan Cordova
-      // picker (no .then handler), which stacks on Android and leaks into the
-      // next tap on iOS (PS-1978).
-      if (this.forcedClick) {
-        this.forcedClick = false;
-
-        return;
-      }
-
       event.preventDefault();
 
-      const getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
-        if ($vm.cameraSource === Camera.PictureSourceType.PHOTOLIBRARY) {
-          $vm.forcedClick = true;
+      let getPicture;
 
-          // Use native element click so the OS file picker opens reliably
-          if ($vm.$refs.imageInput && typeof $vm.$refs.imageInput.click === 'function') {
-            $vm.$refs.imageInput.click();
-          } else {
+      // Re-entry from the jQuery trigger('click') in the PHOTOLIBRARY branch
+      // below. jQuery's trigger fires the JS click event without opening the
+      // browser's native file picker, so this branch is responsible for opening
+      // the Cordova picker and its result must flow through onSelectedPicture
+      // below — do NOT early-return here (PS-1978).
+      if (this.forcedClick) {
+        this.forcedClick = false;
+        getPicture = $vm.getPicture();
+      } else {
+        getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
+          if ($vm.cameraSource === Camera.PictureSourceType.PHOTOLIBRARY) {
+            $vm.forcedClick = true;
+
+            // jQuery trigger — re-enters onFileClick without opening the
+            // browser's native file picker (which is unreliable from this
+            // async context in Android WebView).
             $($vm.$refs.imageInput).trigger('click');
+
+            return Promise.reject('Switch to HTML file input to select files');
           }
 
-          return Promise.reject('Switch to HTML file input to select files');
-        }
-
-        return $vm.getPicture();
-      });
+          return $vm.getPicture();
+        });
+      }
 
       this.validateValue();
 

--- a/js/components/image.js
+++ b/js/components/image.js
@@ -311,23 +311,20 @@ Fliplet.FormBuilder.field('image', {
         return;
       }
 
-      let getPicture;
-
+      // Re-entry from imageInput.click() in the PHOTOLIBRARY branch below — the
+      // native HTML file picker is about to open and onFileChange will deliver
+      // the result. Calling getPicture() here opens a second, orphan Cordova
+      // picker (no .then handler), which stacks on Android and leaks into the
+      // next tap on iOS (PS-1978).
       if (this.forcedClick) {
         this.forcedClick = false;
-
-        try {
-          getPicture = $vm.getPicture();
-        } catch (error) {
-          console.error('Failed to get picture', error);
-        }
 
         return;
       }
 
       event.preventDefault();
 
-      getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
+      const getPicture = this.requestPicture(this.$refs.imageInput).then(function onRequestedPicture() {
         if ($vm.cameraSource === Camera.PictureSourceType.PHOTOLIBRARY) {
           $vm.forcedClick = true;
 


### PR DESCRIPTION
## Release: `release/PS-1978` → `production`

| Title | Ticket | PR |
|-------|--------|-----|
| Route image PHOTOLIBRARY path through Cordova picker (jQuery re-entry) | [PS-1978](https://weboo.atlassian.net/browse/PS-1978) | #878 |
| Ensures image upload doesn't open duplicate pickers | [PS-1978](https://weboo.atlassian.net/browse/PS-1978) | #877 |

### Deployment instructions
Standard widget release — no data or config migration required. Net change is `js/components/image.js` only.

**⚠️ Gate before merge:** PS-1192 / PS-1978 area has reverted 3× on desk reviews. Verify on a real Portal build, iOS + Android: Take Photo, Choose Existing Photo (first + repeat tap), cancel-then-retry. Confirm no regression in Studio preview / Web Live.

[PS-1978]: https://weboo.atlassian.net/browse/PS-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PS-1978]: https://weboo.atlassian.net/browse/PS-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ